### PR TITLE
Adds fluent setters to requests

### DIFF
--- a/lib/PayPal/Api/Address.php
+++ b/lib/PayPal/Api/Address.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,126 +7,132 @@ namespace PayPal\Api;
  */
 class Address extends Resource {
 
+    /**
+     * Setter for line1
+     * @param string $line1
+     */
+    public function setLine1($line1) {
+        $this->line1 = $line1;
+        return $this;
+    }
 
-	/**
-	 * Setter for line1
-	 * @param string $line1
-	 */ 
-	public function setLine1($line1) {
-		$this->line1 = $line1;
-	}
+    /**
+     * Getter for line1
+     */
+    public function getLine1() {
+        return $this->line1;
+    }
 
-	/**
-	 * Getter for line1
-	 */ 
-	public function getLine1() {
-		return $this->line1;
-	}
+    /**
+     * Setter for line2
+     * @param string $line2
+     */
+    public function setLine2($line2) {
+        $this->line2 = $line2;
+        return $this;
+    }
 
-	/**
-	 * Setter for line2
-	 * @param string $line2
-	 */ 
-	public function setLine2($line2) {
-		$this->line2 = $line2;
-	}
+    /**
+     * Getter for line2
+     */
+    public function getLine2() {
+        return $this->line2;
+    }
 
-	/**
-	 * Getter for line2
-	 */ 
-	public function getLine2() {
-		return $this->line2;
-	}
+    /**
+     * Setter for city
+     * @param string $city
+     */
+    public function setCity($city) {
+        $this->city = $city;
+        return $this;
+    }
 
-	/**
-	 * Setter for city
-	 * @param string $city
-	 */ 
-	public function setCity($city) {
-		$this->city = $city;
-	}
+    /**
+     * Getter for city
+     */
+    public function getCity() {
+        return $this->city;
+    }
 
-	/**
-	 * Getter for city
-	 */ 
-	public function getCity() {
-		return $this->city;
-	}
+    /**
+     * Setter for state
+     * @param string $state
+     */
+    public function setState($state) {
+        $this->state = $state;
+        return $this;
+    }
 
-	/**
-	 * Setter for state
-	 * @param string $state
-	 */ 
-	public function setState($state) {
-		$this->state = $state;
-	}
+    /**
+     * Getter for state
+     */
+    public function getState() {
+        return $this->state;
+    }
 
-	/**
-	 * Getter for state
-	 */ 
-	public function getState() {
-		return $this->state;
-	}
+    /**
+     * Setter for postal_code
+     * @param string $postal_code
+     */
+    public function setPostal_code($postal_code) {
+        $this->postal_code = $postal_code;
+        return $this;
+    }
 
-	/**
-	 * Setter for postal_code
-	 * @param string $postal_code
-	 */ 
-	public function setPostal_code($postal_code) {
-		$this->postal_code = $postal_code;
-	}
+    /**
+     * Getter for postal_code
+     */
+    public function getPostal_code() {
+        return $this->postal_code;
+    }
 
-	/**
-	 * Getter for postal_code
-	 */ 
-	public function getPostal_code() {
-		return $this->postal_code;
-	}
+    /**
+     * Setter for country_code
+     * @param string $country_code
+     */
+    public function setCountry_code($country_code) {
+        $this->country_code = $country_code;
+        return $this;
+    }
 
-	/**
-	 * Setter for country_code
-	 * @param string $country_code
-	 */ 
-	public function setCountry_code($country_code) {
-		$this->country_code = $country_code;
-	}
+    /**
+     * Getter for country_code
+     */
+    public function getCountry_code() {
+        return $this->country_code;
+    }
 
-	/**
-	 * Getter for country_code
-	 */ 
-	public function getCountry_code() {
-		return $this->country_code;
-	}
+    /**
+     * Setter for type
+     * @param string $type
+     */
+    public function setType($type) {
+        $this->type = $type;
+        return $this;
+    }
 
-	/**
-	 * Setter for type
-	 * @param string $type
-	 */ 
-	public function setType($type) {
-		$this->type = $type;
-	}
+    /**
+     * Getter for type
+     */
+    public function getType() {
+        return $this->type;
+    }
 
-	/**
-	 * Getter for type
-	 */ 
-	public function getType() {
-		return $this->type;
-	}
+    /**
+     * Setter for phone
+     * @param string $phone
+     */
+    public function setPhone($phone) {
+        $this->phone = $phone;
+        return $this;
+    }
 
-	/**
-	 * Setter for phone
-	 * @param string $phone
-	 */ 
-	public function setPhone($phone) {
-		$this->phone = $phone;
-	}
-
-	/**
-	 * Getter for phone
-	 */ 
-	public function getPhone() {
-		return $this->phone;
-	}
-
+    /**
+     * Getter for phone
+     */
+    public function getPhone() {
+        return $this->phone;
+    }
 
 }

--- a/lib/PayPal/Api/Amount.php
+++ b/lib/PayPal/Api/Amount.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,51 +7,52 @@ namespace PayPal\Api;
  */
 class Amount extends Resource {
 
+    /**
+     * Setter for total
+     * @param string $total
+     */
+    public function setTotal($total) {
+        $this->total = $total;
+        return $this;
+    }
 
-	/**
-	 * Setter for total
-	 * @param string $total
-	 */ 
-	public function setTotal($total) {
-		$this->total = $total;
-	}
+    /**
+     * Getter for total
+     */
+    public function getTotal() {
+        return $this->total;
+    }
 
-	/**
-	 * Getter for total
-	 */ 
-	public function getTotal() {
-		return $this->total;
-	}
+    /**
+     * Setter for currency
+     * @param string $currency
+     */
+    public function setCurrency($currency) {
+        $this->currency = $currency;
+        return $this;
+    }
 
-	/**
-	 * Setter for currency
-	 * @param string $currency
-	 */ 
-	public function setCurrency($currency) {
-		$this->currency = $currency;
-	}
+    /**
+     * Getter for currency
+     */
+    public function getCurrency() {
+        return $this->currency;
+    }
 
-	/**
-	 * Getter for currency
-	 */ 
-	public function getCurrency() {
-		return $this->currency;
-	}
+    /**
+     * Setter for details
+     * @param PayPal\Api\AmountDetails $details
+     */
+    public function setDetails($details) {
+        $this->details = $details;
+        return $this;
+    }
 
-	/**
-	 * Setter for details
-	 * @param PayPal\Api\AmountDetails $details
-	 */ 
-	public function setDetails($details) {
-		$this->details = $details;
-	}
-
-	/**
-	 * Getter for details
-	 */ 
-	public function getDetails() {
-		return $this->details;
-	}
-
+    /**
+     * Getter for details
+     */
+    public function getDetails() {
+        return $this->details;
+    }
 
 }

--- a/lib/PayPal/Api/AmountDetails.php
+++ b/lib/PayPal/Api/AmountDetails.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,66 +7,68 @@ namespace PayPal\Api;
  */
 class AmountDetails extends Resource {
 
+    /**
+     * Setter for subtotal
+     * @param string $subtotal
+     */
+    public function setSubtotal($subtotal) {
+        $this->subtotal = $subtotal;
+        return $this;
+    }
 
-	/**
-	 * Setter for subtotal
-	 * @param string $subtotal
-	 */ 
-	public function setSubtotal($subtotal) {
-		$this->subtotal = $subtotal;
-	}
+    /**
+     * Getter for subtotal
+     */
+    public function getSubtotal() {
+        return $this->subtotal;
+    }
 
-	/**
-	 * Getter for subtotal
-	 */ 
-	public function getSubtotal() {
-		return $this->subtotal;
-	}
+    /**
+     * Setter for tax
+     * @param string $tax
+     */
+    public function setTax($tax) {
+        $this->tax = $tax;
+        return $this;
+    }
 
-	/**
-	 * Setter for tax
-	 * @param string $tax
-	 */ 
-	public function setTax($tax) {
-		$this->tax = $tax;
-	}
+    /**
+     * Getter for tax
+     */
+    public function getTax() {
+        return $this->tax;
+    }
 
-	/**
-	 * Getter for tax
-	 */ 
-	public function getTax() {
-		return $this->tax;
-	}
+    /**
+     * Setter for shipping
+     * @param string $shipping
+     */
+    public function setShipping($shipping) {
+        $this->shipping = $shipping;
+        return $this;
+    }
 
-	/**
-	 * Setter for shipping
-	 * @param string $shipping
-	 */ 
-	public function setShipping($shipping) {
-		$this->shipping = $shipping;
-	}
+    /**
+     * Getter for shipping
+     */
+    public function getShipping() {
+        return $this->shipping;
+    }
 
-	/**
-	 * Getter for shipping
-	 */ 
-	public function getShipping() {
-		return $this->shipping;
-	}
+    /**
+     * Setter for fee
+     * @param string $fee
+     */
+    public function setFee($fee) {
+        $this->fee = $fee;
+        return $this;
+    }
 
-	/**
-	 * Setter for fee
-	 * @param string $fee
-	 */ 
-	public function setFee($fee) {
-		$this->fee = $fee;
-	}
-
-	/**
-	 * Getter for fee
-	 */ 
-	public function getFee() {
-		return $this->fee;
-	}
-
+    /**
+     * Getter for fee
+     */
+    public function getFee() {
+        return $this->fee;
+    }
 
 }

--- a/lib/PayPal/Api/Authorization.php
+++ b/lib/PayPal/Api/Authorization.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,111 +7,116 @@ namespace PayPal\Api;
  */
 class Authorization extends Resource {
 
+    /**
+     * Setter for id
+     * @param string $id
+     */
+    public function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
 
-	/**
-	 * Setter for id
-	 * @param string $id
-	 */ 
-	public function setId($id) {
-		$this->id = $id;
-	}
+    /**
+     * Getter for id
+     */
+    public function getId() {
+        return $this->id;
+    }
 
-	/**
-	 * Getter for id
-	 */ 
-	public function getId() {
-		return $this->id;
-	}
+    /**
+     * Setter for create_time
+     * @param string $create_time
+     */
+    public function setCreate_time($create_time) {
+        $this->create_time = $create_time;
+        return $this;
+    }
 
-	/**
-	 * Setter for create_time
-	 * @param string $create_time
-	 */ 
-	public function setCreate_time($create_time) {
-		$this->create_time = $create_time;
-	}
+    /**
+     * Getter for create_time
+     */
+    public function getCreate_time() {
+        return $this->create_time;
+    }
 
-	/**
-	 * Getter for create_time
-	 */ 
-	public function getCreate_time() {
-		return $this->create_time;
-	}
+    /**
+     * Setter for update_time
+     * @param string $update_time
+     */
+    public function setUpdate_time($update_time) {
+        $this->update_time = $update_time;
+        return $this;
+    }
 
-	/**
-	 * Setter for update_time
-	 * @param string $update_time
-	 */ 
-	public function setUpdate_time($update_time) {
-		$this->update_time = $update_time;
-	}
+    /**
+     * Getter for update_time
+     */
+    public function getUpdate_time() {
+        return $this->update_time;
+    }
 
-	/**
-	 * Getter for update_time
-	 */ 
-	public function getUpdate_time() {
-		return $this->update_time;
-	}
+    /**
+     * Setter for state
+     * @param string $state
+     */
+    public function setState($state) {
+        $this->state = $state;
+        return $this;
+    }
 
-	/**
-	 * Setter for state
-	 * @param string $state
-	 */ 
-	public function setState($state) {
-		$this->state = $state;
-	}
+    /**
+     * Getter for state
+     */
+    public function getState() {
+        return $this->state;
+    }
 
-	/**
-	 * Getter for state
-	 */ 
-	public function getState() {
-		return $this->state;
-	}
+    /**
+     * Setter for amount
+     * @param PayPal\Api\Amount $amount
+     */
+    public function setAmount($amount) {
+        $this->amount = $amount;
+        return $this;
+    }
 
-	/**
-	 * Setter for amount
-	 * @param PayPal\Api\Amount $amount
-	 */ 
-	public function setAmount($amount) {
-		$this->amount = $amount;
-	}
+    /**
+     * Getter for amount
+     */
+    public function getAmount() {
+        return $this->amount;
+    }
 
-	/**
-	 * Getter for amount
-	 */ 
-	public function getAmount() {
-		return $this->amount;
-	}
+    /**
+     * Setter for parent_payment
+     * @param string $parent_payment
+     */
+    public function setParent_payment($parent_payment) {
+        $this->parent_payment = $parent_payment;
+        return $this;
+    }
 
-	/**
-	 * Setter for parent_payment
-	 * @param string $parent_payment
-	 */ 
-	public function setParent_payment($parent_payment) {
-		$this->parent_payment = $parent_payment;
-	}
+    /**
+     * Getter for parent_payment
+     */
+    public function getParent_payment() {
+        return $this->parent_payment;
+    }
 
-	/**
-	 * Getter for parent_payment
-	 */ 
-	public function getParent_payment() {
-		return $this->parent_payment;
-	}
+    /**
+     * Setter for links
+     * @param PayPal\Api\Link $links
+     */
+    public function setLinks($links) {
+        $this->links = $links;
+        return $this;
+    }
 
-	/**
-	 * Setter for links
-	 * @param PayPal\Api\Link $links
-	 */ 
-	public function setLinks($links) {
-		$this->links = $links;
-	}
-
-	/**
-	 * Getter for links
-	 */ 
-	public function getLinks() {
-		return $this->links;
-	}
-
+    /**
+     * Getter for links
+     */
+    public function getLinks() {
+        return $this->links;
+    }
 
 }

--- a/lib/PayPal/Api/Capture.php
+++ b/lib/PayPal/Api/Capture.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,141 +7,147 @@ namespace PayPal\Api;
  */
 class Capture extends Resource {
 
+    /**
+     * Setter for id
+     * @param string $id
+     */
+    public function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
 
-	/**
-	 * Setter for id
-	 * @param string $id
-	 */ 
-	public function setId($id) {
-		$this->id = $id;
-	}
+    /**
+     * Getter for id
+     */
+    public function getId() {
+        return $this->id;
+    }
 
-	/**
-	 * Getter for id
-	 */ 
-	public function getId() {
-		return $this->id;
-	}
+    /**
+     * Setter for create_time
+     * @param string $create_time
+     */
+    public function setCreate_time($create_time) {
+        $this->create_time = $create_time;
+        return $this;
+    }
 
-	/**
-	 * Setter for create_time
-	 * @param string $create_time
-	 */ 
-	public function setCreate_time($create_time) {
-		$this->create_time = $create_time;
-	}
+    /**
+     * Getter for create_time
+     */
+    public function getCreate_time() {
+        return $this->create_time;
+    }
 
-	/**
-	 * Getter for create_time
-	 */ 
-	public function getCreate_time() {
-		return $this->create_time;
-	}
+    /**
+     * Setter for update_time
+     * @param string $update_time
+     */
+    public function setUpdate_time($update_time) {
+        $this->update_time = $update_time;
+        return $this;
+    }
 
-	/**
-	 * Setter for update_time
-	 * @param string $update_time
-	 */ 
-	public function setUpdate_time($update_time) {
-		$this->update_time = $update_time;
-	}
+    /**
+     * Getter for update_time
+     */
+    public function getUpdate_time() {
+        return $this->update_time;
+    }
 
-	/**
-	 * Getter for update_time
-	 */ 
-	public function getUpdate_time() {
-		return $this->update_time;
-	}
+    /**
+     * Setter for state
+     * @param string $state
+     */
+    public function setState($state) {
+        $this->state = $state;
+        return $this;
+    }
 
-	/**
-	 * Setter for state
-	 * @param string $state
-	 */ 
-	public function setState($state) {
-		$this->state = $state;
-	}
+    /**
+     * Getter for state
+     */
+    public function getState() {
+        return $this->state;
+    }
 
-	/**
-	 * Getter for state
-	 */ 
-	public function getState() {
-		return $this->state;
-	}
+    /**
+     * Setter for amount
+     * @param PayPal\Api\Amount $amount
+     */
+    public function setAmount($amount) {
+        $this->amount = $amount;
+    }
 
-	/**
-	 * Setter for amount
-	 * @param PayPal\Api\Amount $amount
-	 */ 
-	public function setAmount($amount) {
-		$this->amount = $amount;
-	}
+    /**
+     * Getter for amount
+     */
+    public function getAmount() {
+        return $this->amount;
+    }
 
-	/**
-	 * Getter for amount
-	 */ 
-	public function getAmount() {
-		return $this->amount;
-	}
+    /**
+     * Setter for parent_payment
+     * @param string $parent_payment
+     */
+    public function setParent_payment($parent_payment) {
+        $this->parent_payment = $parent_payment;
+        return $this;
+    }
 
-	/**
-	 * Setter for parent_payment
-	 * @param string $parent_payment
-	 */ 
-	public function setParent_payment($parent_payment) {
-		$this->parent_payment = $parent_payment;
-	}
+    /**
+     * Getter for parent_payment
+     */
+    public function getParent_payment() {
+        return $this->parent_payment;
+    }
 
-	/**
-	 * Getter for parent_payment
-	 */ 
-	public function getParent_payment() {
-		return $this->parent_payment;
-	}
+    /**
+     * Setter for authorization_id
+     * @param string $authorization_id
+     */
+    public function setAuthorization_id($authorization_id) {
+        $this->authorization_id = $authorization_id;
+        return $this;
+    }
 
-	/**
-	 * Setter for authorization_id
-	 * @param string $authorization_id
-	 */ 
-	public function setAuthorization_id($authorization_id) {
-		$this->authorization_id = $authorization_id;
-	}
+    /**
+     * Getter for authorization_id
+     */
+    public function getAuthorization_id() {
+        return $this->authorization_id;
+    }
 
-	/**
-	 * Getter for authorization_id
-	 */ 
-	public function getAuthorization_id() {
-		return $this->authorization_id;
-	}
+    /**
+     * Setter for description
+     * @param string $description
+     */
+    public function setDescription($description) {
+        $this->description = $description;
+        return $this;
+    }
 
-	/**
-	 * Setter for description
-	 * @param string $description
-	 */ 
-	public function setDescription($description) {
-		$this->description = $description;
-	}
+    /**
+     * Getter for description
+     */
+    public function getDescription() {
+        return $this->description;
+    }
 
-	/**
-	 * Getter for description
-	 */ 
-	public function getDescription() {
-		return $this->description;
-	}
+    /**
+     * Setter for links
+     * @param PayPal\Api\Link $links
+     */
+    public function setLinks($links) {
+        $this->links = $links;
+        return $this;
+    }
 
-	/**
-	 * Setter for links
-	 * @param PayPal\Api\Link $links
-	 */ 
-	public function setLinks($links) {
-		$this->links = $links;
-	}
-
-	/**
-	 * Getter for links
-	 */ 
-	public function getLinks() {
-		return $this->links;
-	}
-
+    /**
+     * Getter for links
+     */
+    public function getLinks() {
+        return $this->links;
+    }
 
 }

--- a/lib/PayPal/Api/CreditCard.php
+++ b/lib/PayPal/Api/CreditCard.php
@@ -1,6 +1,7 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
+
 use PayPal\Rest\IResource;
 use PayPal\Rest\Call;
 use PayPal\Rest\ApiContext;
@@ -10,244 +11,254 @@ use PayPal\Rest\ApiContext;
  */
 class CreditCard extends Resource implements IResource {
 
-	private static $credential;
-	
-	public static function setCredential($credential) {
-		self::$credential = $credential;
-	}
-	
-	/**
-	 * Setter for id
-	 * @param string $id
-	 */ 
-	public function setId($id) {
-		$this->id = $id;
-	}
+    private static $credential;
 
-	/**
-	 * Getter for id
-	 */ 
-	public function getId() {
-		return $this->id;
-	}
+    public static function setCredential($credential) {
+        self::$credential = $credential;
+    }
 
-	/**
-	 * Setter for valid_until
-	 * @param string $valid_until
-	 */ 
-	public function setValid_until($valid_until) {
-		$this->valid_until = $valid_until;
-	}
+    /**
+     * Setter for id
+     * @param string $id
+     */
+    public function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
 
-	/**
-	 * Getter for valid_until
-	 */ 
-	public function getValid_until() {
-		return $this->valid_until;
-	}
+    /**
+     * Getter for id
+     */
+    public function getId() {
+        return $this->id;
+    }
 
-	/**
-	 * Setter for state
-	 * @param string $state
-	 */ 
-	public function setState($state) {
-		$this->state = $state;
-	}
+    /**
+     * Setter for valid_until
+     * @param string $valid_until
+     */
+    public function setValid_until($valid_until) {
+        $this->valid_until = $valid_until;
+        return $this;
+    }
 
-	/**
-	 * Getter for state
-	 */ 
-	public function getState() {
-		return $this->state;
-	}
+    /**
+     * Getter for valid_until
+     */
+    public function getValid_until() {
+        return $this->valid_until;
+    }
 
-	/**
-	 * Setter for payer_id
-	 * @param string $payer_id
-	 */ 
-	public function setPayer_id($payer_id) {
-		$this->payer_id = $payer_id;
-	}
+    /**
+     * Setter for state
+     * @param string $state
+     */
+    public function setState($state) {
+        $this->state = $state;
+        return $this;
+    }
 
-	/**
-	 * Getter for payer_id
-	 */ 
-	public function getPayer_id() {
-		return $this->payer_id;
-	}
+    /**
+     * Getter for state
+     */
+    public function getState() {
+        return $this->state;
+    }
 
-	/**
-	 * Setter for type
-	 * @param string $type
-	 */ 
-	public function setType($type) {
-		$this->type = $type;
-	}
+    /**
+     * Setter for payer_id
+     * @param string $payer_id
+     */
+    public function setPayer_id($payer_id) {
+        $this->payer_id = $payer_id;
+        return $this;
+    }
 
-	/**
-	 * Getter for type
-	 */ 
-	public function getType() {
-		return $this->type;
-	}
+    /**
+     * Getter for payer_id
+     */
+    public function getPayer_id() {
+        return $this->payer_id;
+    }
 
-	/**
-	 * Setter for number
-	 * @param string $number
-	 */ 
-	public function setNumber($number) {
-		$this->number = $number;
-	}
+    /**
+     * Setter for type
+     * @param string $type
+     */
+    public function setType($type) {
+        $this->type = $type;
+        return $this;
+    }
 
-	/**
-	 * Getter for number
-	 */ 
-	public function getNumber() {
-		return $this->number;
-	}
+    /**
+     * Getter for type
+     */
+    public function getType() {
+        return $this->type;
+    }
 
-	/**
-	 * Setter for expire_month
-	 * @param string $expire_month
-	 */ 
-	public function setExpire_month($expire_month) {
-		$this->expire_month = $expire_month;
-	}
+    /**
+     * Setter for number
+     * @param string $number
+     */
+    public function setNumber($number) {
+        $this->number = $number;
+        return $this;
+    }
 
-	/**
-	 * Getter for expire_month
-	 */ 
-	public function getExpire_month() {
-		return $this->expire_month;
-	}
+    /**
+     * Getter for number
+     */
+    public function getNumber() {
+        return $this->number;
+    }
 
-	/**
-	 * Setter for expire_year
-	 * @param string $expire_year
-	 */ 
-	public function setExpire_year($expire_year) {
-		$this->expire_year = $expire_year;
-	}
+    /**
+     * Setter for expire_month
+     * @param string $expire_month
+     */
+    public function setExpire_month($expire_month) {
+        $this->expire_month = $expire_month;
+        return $this;
+    }
 
-	/**
-	 * Getter for expire_year
-	 */ 
-	public function getExpire_year() {
-		return $this->expire_year;
-	}
+    /**
+     * Getter for expire_month
+     */
+    public function getExpire_month() {
+        return $this->expire_month;
+    }
 
-	/**
-	 * Setter for cvv2
-	 * @param string $cvv2
-	 */ 
-	public function setCvv2($cvv2) {
-		$this->cvv2 = $cvv2;
-	}
+    /**
+     * Setter for expire_year
+     * @param string $expire_year
+     */
+    public function setExpire_year($expire_year) {
+        $this->expire_year = $expire_year;
+        return $this;
+    }
 
-	/**
-	 * Getter for cvv2
-	 */ 
-	public function getCvv2() {
-		return $this->cvv2;
-	}
+    /**
+     * Getter for expire_year
+     */
+    public function getExpire_year() {
+        return $this->expire_year;
+    }
 
-	/**
-	 * Setter for first_name
-	 * @param string $first_name
-	 */ 
-	public function setFirst_name($first_name) {
-		$this->first_name = $first_name;
-	}
+    /**
+     * Setter for cvv2
+     * @param string $cvv2
+     */
+    public function setCvv2($cvv2) {
+        $this->cvv2 = $cvv2;
+        return $this;
+    }
 
-	/**
-	 * Getter for first_name
-	 */ 
-	public function getFirst_name() {
-		return $this->first_name;
-	}
+    /**
+     * Getter for cvv2
+     */
+    public function getCvv2() {
+        return $this->cvv2;
+    }
 
-	/**
-	 * Setter for last_name
-	 * @param string $last_name
-	 */ 
-	public function setLast_name($last_name) {
-		$this->last_name = $last_name;
-	}
+    /**
+     * Setter for first_name
+     * @param string $first_name
+     */
+    public function setFirst_name($first_name) {
+        $this->first_name = $first_name;
+        return $this;
+    }
 
-	/**
-	 * Getter for last_name
-	 */ 
-	public function getLast_name() {
-		return $this->last_name;
-	}
+    /**
+     * Getter for first_name
+     */
+    public function getFirst_name() {
+        return $this->first_name;
+    }
 
-	/**
-	 * Setter for billing_address
-	 * @param PayPal\Api\Address $billing_address
-	 */ 
-	public function setBilling_address($billing_address) {
-		$this->billing_address = $billing_address;
-	}
+    /**
+     * Setter for last_name
+     * @param string $last_name
+     */
+    public function setLast_name($last_name) {
+        $this->last_name = $last_name;
+        return $this;
+    }
 
-	/**
-	 * Getter for billing_address
-	 */ 
-	public function getBilling_address() {
-		return $this->billing_address;
-	}
+    /**
+     * Getter for last_name
+     */
+    public function getLast_name() {
+        return $this->last_name;
+    }
 
-	/**
-	 * Setter for links
-	 * @param PayPal\Api\Link $links
-	 */ 
-	public function setLinks($links) {
-		$this->links = $links;
-	}
+    /**
+     * Setter for billing_address
+     * @param PayPal\Api\Address $billing_address
+     */
+    public function setBilling_address($billing_address) {
+        $this->billing_address = $billing_address;
+        return $this;
+    }
 
-	/**
-	 * Getter for links
-	 */ 
-	public function getLinks() {
-		return $this->links;
-	}
+    /**
+     * Getter for billing_address
+     */
+    public function getBilling_address() {
+        return $this->billing_address;
+    }
 
-	
-	
-	/**
-	 * @path /v1/vault/credit-card
-	 * @method POST
-	  
-	 * @param PayPal\Rest\ApiContext $apiContext optional	  	 
-	 */
-	public function create( $apiContext=null) {
-		$payLoad = $this->toJSON();	
-		if($apiContext == null) {
-			$apiContext = new ApiContext(self::$credential);
-		}
-		$call = new Call();		
-		$json = $call->execute("/v1/vault/credit-card", "POST", $payLoad, $apiContext);
-		$this->fromJson($json);
- 		return $this; 		
- 	}
-	
-	/**
-	 * @path /v1/vault/credit-card/:credit-card-id
-	 * @method GET
-	 * @param string $creditcardid	  	 
-	 */
-	public static function get( $creditcardid) {
-		if (($creditcardid == null) || (strlen($creditcardid) <= 0)) {
-			throw new \InvalidArgumentException("creditcardid cannot be null or empty");
-		}
-		$payLoad = "";
-		
-		$apiContext = new ApiContext(self::$credential);		$call = new Call();		
-		$json = $call->execute("/v1/vault/credit-card/$creditcardid", "GET", $payLoad, $apiContext);
-		$ret = new CreditCard();
-		$ret->fromJson($json);
-		return $ret;
- 		 		
- 	}
-	
+    /**
+     * Setter for links
+     * @param PayPal\Api\Link $links
+     */
+    public function setLinks($links) {
+        $this->links = $links;
+        return $this;
+    }
+
+    /**
+     * Getter for links
+     */
+    public function getLinks() {
+        return $this->links;
+    }
+
+    /**
+     * @path /v1/vault/credit-card
+     * @method POST
+
+     * @param PayPal\Rest\ApiContext $apiContext optional	  	 
+     */
+    public function create($apiContext = null) {
+        $payLoad = $this->toJSON();
+        if ($apiContext == null) {
+            $apiContext = new ApiContext(self::$credential);
+        }
+        $call = new Call();
+        $json = $call->execute("/v1/vault/credit-card", "POST", $payLoad, $apiContext);
+        $this->fromJson($json);
+        return $this;
+    }
+
+    /**
+     * @path /v1/vault/credit-card/:credit-card-id
+     * @method GET
+     * @param string $creditcardid	  	 
+     */
+    public static function get($creditcardid) {
+        if (($creditcardid == null) || (strlen($creditcardid) <= 0)) {
+            throw new \InvalidArgumentException("creditcardid cannot be null or empty");
+        }
+        $payLoad = "";
+
+        $apiContext = new ApiContext(self::$credential);
+        $call = new Call();
+        $json = $call->execute("/v1/vault/credit-card/$creditcardid", "GET", $payLoad, $apiContext);
+        $ret = new CreditCard();
+        $ret->fromJson($json);
+        return $ret;
+    }
 
 }

--- a/lib/PayPal/Api/CreditCardToken.php
+++ b/lib/PayPal/Api/CreditCardToken.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,36 +7,36 @@ namespace PayPal\Api;
  */
 class CreditCardToken extends Resource {
 
+    /**
+     * Setter for credit_card_id
+     * @param string $credit_card_id
+     */
+    public function setCredit_card_id($credit_card_id) {
+        $this->credit_card_id = $credit_card_id;
+        return $this;
+    }
 
-	/**
-	 * Setter for credit_card_id
-	 * @param string $credit_card_id
-	 */ 
-	public function setCredit_card_id($credit_card_id) {
-		$this->credit_card_id = $credit_card_id;
-	}
+    /**
+     * Getter for credit_card_id
+     */
+    public function getCredit_card_id() {
+        return $this->credit_card_id;
+    }
 
-	/**
-	 * Getter for credit_card_id
-	 */ 
-	public function getCredit_card_id() {
-		return $this->credit_card_id;
-	}
+    /**
+     * Setter for payer_id
+     * @param string $payer_id
+     */
+    public function setPayer_id($payer_id) {
+        $this->payer_id = $payer_id;
+        return $this;
+    }
 
-	/**
-	 * Setter for payer_id
-	 * @param string $payer_id
-	 */ 
-	public function setPayer_id($payer_id) {
-		$this->payer_id = $payer_id;
-	}
-
-	/**
-	 * Getter for payer_id
-	 */ 
-	public function getPayer_id() {
-		return $this->payer_id;
-	}
-
+    /**
+     * Getter for payer_id
+     */
+    public function getPayer_id() {
+        return $this->payer_id;
+    }
 
 }

--- a/lib/PayPal/Api/FundingInstrument.php
+++ b/lib/PayPal/Api/FundingInstrument.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,36 +7,36 @@ namespace PayPal\Api;
  */
 class FundingInstrument extends Resource {
 
+    /**
+     * Setter for credit_card
+     * @param PayPal\Api\CreditCard $credit_card
+     */
+    public function setCredit_card($credit_card) {
+        $this->credit_card = $credit_card;
+        return $this;
+    }
 
-	/**
-	 * Setter for credit_card
-	 * @param PayPal\Api\CreditCard $credit_card
-	 */ 
-	public function setCredit_card($credit_card) {
-		$this->credit_card = $credit_card;
-	}
+    /**
+     * Getter for credit_card
+     */
+    public function getCredit_card() {
+        return $this->credit_card;
+    }
 
-	/**
-	 * Getter for credit_card
-	 */ 
-	public function getCredit_card() {
-		return $this->credit_card;
-	}
+    /**
+     * Setter for credit_card_token
+     * @param PayPal\Api\CreditCardToken $credit_card_token
+     */
+    public function setCredit_card_token($credit_card_token) {
+        $this->credit_card_token = $credit_card_token;
+        return $this;
+    }
 
-	/**
-	 * Setter for credit_card_token
-	 * @param PayPal\Api\CreditCardToken $credit_card_token
-	 */ 
-	public function setCredit_card_token($credit_card_token) {
-		$this->credit_card_token = $credit_card_token;
-	}
-
-	/**
-	 * Getter for credit_card_token
-	 */ 
-	public function getCredit_card_token() {
-		return $this->credit_card_token;
-	}
-
+    /**
+     * Getter for credit_card_token
+     */
+    public function getCredit_card_token() {
+        return $this->credit_card_token;
+    }
 
 }

--- a/lib/PayPal/Api/Item.php
+++ b/lib/PayPal/Api/Item.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,81 +7,84 @@ namespace PayPal\Api;
  */
 class Item extends Resource {
 
+    /**
+     * Setter for name
+     * @param string $name
+     */
+    public function setName($name) {
+        $this->name = $name;
+        return $this;
+    }
 
-	/**
-	 * Setter for name
-	 * @param string $name
-	 */ 
-	public function setName($name) {
-		$this->name = $name;
-	}
+    /**
+     * Getter for name
+     */
+    public function getName() {
+        return $this->name;
+    }
 
-	/**
-	 * Getter for name
-	 */ 
-	public function getName() {
-		return $this->name;
-	}
+    /**
+     * Setter for sku
+     * @param string $sku
+     */
+    public function setSku($sku) {
+        $this->sku = $sku;
+        return $this;
+    }
 
-	/**
-	 * Setter for sku
-	 * @param string $sku
-	 */ 
-	public function setSku($sku) {
-		$this->sku = $sku;
-	}
+    /**
+     * Getter for sku
+     */
+    public function getSku() {
+        return $this->sku;
+    }
 
-	/**
-	 * Getter for sku
-	 */ 
-	public function getSku() {
-		return $this->sku;
-	}
+    /**
+     * Setter for price
+     * @param string $price
+     */
+    public function setPrice($price) {
+        $this->price = $price;
+        return $this;
+    }
 
-	/**
-	 * Setter for price
-	 * @param string $price
-	 */ 
-	public function setPrice($price) {
-		$this->price = $price;
-	}
+    /**
+     * Getter for price
+     */
+    public function getPrice() {
+        return $this->price;
+    }
 
-	/**
-	 * Getter for price
-	 */ 
-	public function getPrice() {
-		return $this->price;
-	}
+    /**
+     * Setter for currency
+     * @param string $currency
+     */
+    public function setCurrency($currency) {
+        $this->currency = $currency;
+        return $this;
+    }
 
-	/**
-	 * Setter for currency
-	 * @param string $currency
-	 */ 
-	public function setCurrency($currency) {
-		$this->currency = $currency;
-	}
+    /**
+     * Getter for currency
+     */
+    public function getCurrency() {
+        return $this->currency;
+    }
 
-	/**
-	 * Getter for currency
-	 */ 
-	public function getCurrency() {
-		return $this->currency;
-	}
+    /**
+     * Setter for quantity
+     * @param string $quantity
+     */
+    public function setQuantity($quantity) {
+        $this->quantity = $quantity;
+        return $this;
+    }
 
-	/**
-	 * Setter for quantity
-	 * @param string $quantity
-	 */ 
-	public function setQuantity($quantity) {
-		$this->quantity = $quantity;
-	}
-
-	/**
-	 * Getter for quantity
-	 */ 
-	public function getQuantity() {
-		return $this->quantity;
-	}
-
+    /**
+     * Getter for quantity
+     */
+    public function getQuantity() {
+        return $this->quantity;
+    }
 
 }

--- a/lib/PayPal/Api/ItemList.php
+++ b/lib/PayPal/Api/ItemList.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,36 +7,36 @@ namespace PayPal\Api;
  */
 class ItemList extends Resource {
 
+    /**
+     * Setter for items
+     * @param PayPal\Api\Item $items
+     */
+    public function setItems($items) {
+        $this->items = $items;
+        return $this;
+    }
 
-	/**
-	 * Setter for items
-	 * @param PayPal\Api\Item $items
-	 */ 
-	public function setItems($items) {
-		$this->items = $items;
-	}
+    /**
+     * Getter for items
+     */
+    public function getItems() {
+        return $this->items;
+    }
 
-	/**
-	 * Getter for items
-	 */ 
-	public function getItems() {
-		return $this->items;
-	}
+    /**
+     * Setter for shipping_address
+     * @param PayPal\Api\ShippingAddress $shipping_address
+     */
+    public function setShipping_address($shipping_address) {
+        $this->shipping_address = $shipping_address;
+        return $this;
+    }
 
-	/**
-	 * Setter for shipping_address
-	 * @param PayPal\Api\ShippingAddress $shipping_address
-	 */ 
-	public function setShipping_address($shipping_address) {
-		$this->shipping_address = $shipping_address;
-	}
-
-	/**
-	 * Getter for shipping_address
-	 */ 
-	public function getShipping_address() {
-		return $this->shipping_address;
-	}
-
+    /**
+     * Getter for shipping_address
+     */
+    public function getShipping_address() {
+        return $this->shipping_address;
+    }
 
 }

--- a/lib/PayPal/Api/Link.php
+++ b/lib/PayPal/Api/Link.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,51 +7,52 @@ namespace PayPal\Api;
  */
 class Link extends Resource {
 
+    /**
+     * Setter for href
+     * @param string $href
+     */
+    public function setHref($href) {
+        $this->href = $href;
+        return $this;
+    }
 
-	/**
-	 * Setter for href
-	 * @param string $href
-	 */ 
-	public function setHref($href) {
-		$this->href = $href;
-	}
+    /**
+     * Getter for href
+     */
+    public function getHref() {
+        return $this->href;
+    }
 
-	/**
-	 * Getter for href
-	 */ 
-	public function getHref() {
-		return $this->href;
-	}
+    /**
+     * Setter for rel
+     * @param string $rel
+     */
+    public function setRel($rel) {
+        $this->rel = $rel;
+        return $this;
+    }
 
-	/**
-	 * Setter for rel
-	 * @param string $rel
-	 */ 
-	public function setRel($rel) {
-		$this->rel = $rel;
-	}
+    /**
+     * Getter for rel
+     */
+    public function getRel() {
+        return $this->rel;
+    }
 
-	/**
-	 * Getter for rel
-	 */ 
-	public function getRel() {
-		return $this->rel;
-	}
+    /**
+     * Setter for method
+     * @param string $method
+     */
+    public function setMethod($method) {
+        $this->method = $method;
+        return $this;
+    }
 
-	/**
-	 * Setter for method
-	 * @param string $method
-	 */ 
-	public function setMethod($method) {
-		$this->method = $method;
-	}
-
-	/**
-	 * Getter for method
-	 */ 
-	public function getMethod() {
-		return $this->method;
-	}
-
+    /**
+     * Getter for method
+     */
+    public function getMethod() {
+        return $this->method;
+    }
 
 }

--- a/lib/PayPal/Api/Payee.php
+++ b/lib/PayPal/Api/Payee.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,51 +7,52 @@ namespace PayPal\Api;
  */
 class Payee extends Resource {
 
+    /**
+     * Setter for merchant_id
+     * @param string $merchant_id
+     */
+    public function setMerchant_id($merchant_id) {
+        $this->merchant_id = $merchant_id;
+        return $this;
+    }
 
-	/**
-	 * Setter for merchant_id
-	 * @param string $merchant_id
-	 */ 
-	public function setMerchant_id($merchant_id) {
-		$this->merchant_id = $merchant_id;
-	}
+    /**
+     * Getter for merchant_id
+     */
+    public function getMerchant_id() {
+        return $this->merchant_id;
+    }
 
-	/**
-	 * Getter for merchant_id
-	 */ 
-	public function getMerchant_id() {
-		return $this->merchant_id;
-	}
+    /**
+     * Setter for email
+     * @param string $email
+     */
+    public function setEmail($email) {
+        $this->email = $email;
+        return $this;
+    }
 
-	/**
-	 * Setter for email
-	 * @param string $email
-	 */ 
-	public function setEmail($email) {
-		$this->email = $email;
-	}
+    /**
+     * Getter for email
+     */
+    public function getEmail() {
+        return $this->email;
+    }
 
-	/**
-	 * Getter for email
-	 */ 
-	public function getEmail() {
-		return $this->email;
-	}
+    /**
+     * Setter for phone
+     * @param string $phone
+     */
+    public function setPhone($phone) {
+        $this->phone = $phone;
+        return $this;
+    }
 
-	/**
-	 * Setter for phone
-	 * @param string $phone
-	 */ 
-	public function setPhone($phone) {
-		$this->phone = $phone;
-	}
-
-	/**
-	 * Getter for phone
-	 */ 
-	public function getPhone() {
-		return $this->phone;
-	}
-
+    /**
+     * Getter for phone
+     */
+    public function getPhone() {
+        return $this->phone;
+    }
 
 }

--- a/lib/PayPal/Api/Payer.php
+++ b/lib/PayPal/Api/Payer.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,51 +7,52 @@ namespace PayPal\Api;
  */
 class Payer extends Resource {
 
+    /**
+     * Setter for payment_method
+     * @param string $payment_method
+     */
+    public function setPayment_method($payment_method) {
+        $this->payment_method = $payment_method;
+        return $this;
+    }
 
-	/**
-	 * Setter for payment_method
-	 * @param string $payment_method
-	 */ 
-	public function setPayment_method($payment_method) {
-		$this->payment_method = $payment_method;
-	}
+    /**
+     * Getter for payment_method
+     */
+    public function getPayment_method() {
+        return $this->payment_method;
+    }
 
-	/**
-	 * Getter for payment_method
-	 */ 
-	public function getPayment_method() {
-		return $this->payment_method;
-	}
+    /**
+     * Setter for payer_info
+     * @param PayPal\Api\PayerInfo $payer_info
+     */
+    public function setPayer_info($payer_info) {
+        $this->payer_info = $payer_info;
+        return $this;
+    }
 
-	/**
-	 * Setter for payer_info
-	 * @param PayPal\Api\PayerInfo $payer_info
-	 */ 
-	public function setPayer_info($payer_info) {
-		$this->payer_info = $payer_info;
-	}
+    /**
+     * Getter for payer_info
+     */
+    public function getPayer_info() {
+        return $this->payer_info;
+    }
 
-	/**
-	 * Getter for payer_info
-	 */ 
-	public function getPayer_info() {
-		return $this->payer_info;
-	}
+    /**
+     * Setter for funding_instruments
+     * @param PayPal\Api\FundingInstrument $funding_instruments
+     */
+    public function setFunding_instruments($funding_instruments) {
+        $this->funding_instruments = $funding_instruments;
+        return $this;
+    }
 
-	/**
-	 * Setter for funding_instruments
-	 * @param PayPal\Api\FundingInstrument $funding_instruments
-	 */ 
-	public function setFunding_instruments($funding_instruments) {
-		$this->funding_instruments = $funding_instruments;
-	}
-
-	/**
-	 * Getter for funding_instruments
-	 */ 
-	public function getFunding_instruments() {
-		return $this->funding_instruments;
-	}
-
+    /**
+     * Getter for funding_instruments
+     */
+    public function getFunding_instruments() {
+        return $this->funding_instruments;
+    }
 
 }

--- a/lib/PayPal/Api/PayerInfo.php
+++ b/lib/PayPal/Api/PayerInfo.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,96 +7,100 @@ namespace PayPal\Api;
  */
 class PayerInfo extends Resource {
 
+    /**
+     * Setter for email
+     * @param string $email
+     */
+    public function setEmail($email) {
+        $this->email = $email;
+        return $this;
+    }
 
-	/**
-	 * Setter for email
-	 * @param string $email
-	 */ 
-	public function setEmail($email) {
-		$this->email = $email;
-	}
+    /**
+     * Getter for email
+     */
+    public function getEmail() {
+        return $this->email;
+    }
 
-	/**
-	 * Getter for email
-	 */ 
-	public function getEmail() {
-		return $this->email;
-	}
+    /**
+     * Setter for first_name
+     * @param string $first_name
+     */
+    public function setFirst_name($first_name) {
+        $this->first_name = $first_name;
+        return $this;
+    }
 
-	/**
-	 * Setter for first_name
-	 * @param string $first_name
-	 */ 
-	public function setFirst_name($first_name) {
-		$this->first_name = $first_name;
-	}
+    /**
+     * Getter for first_name
+     */
+    public function getFirst_name() {
+        return $this->first_name;
+    }
 
-	/**
-	 * Getter for first_name
-	 */ 
-	public function getFirst_name() {
-		return $this->first_name;
-	}
+    /**
+     * Setter for last_name
+     * @param string $last_name
+     */
+    public function setLast_name($last_name) {
+        $this->last_name = $last_name;
+        return $this;
+    }
 
-	/**
-	 * Setter for last_name
-	 * @param string $last_name
-	 */ 
-	public function setLast_name($last_name) {
-		$this->last_name = $last_name;
-	}
+    /**
+     * Getter for last_name
+     */
+    public function getLast_name() {
+        return $this->last_name;
+    }
 
-	/**
-	 * Getter for last_name
-	 */ 
-	public function getLast_name() {
-		return $this->last_name;
-	}
+    /**
+     * Setter for payer_id
+     * @param string $payer_id
+     */
+    public function setPayer_id($payer_id) {
+        $this->payer_id = $payer_id;
+        return $this;
+    }
 
-	/**
-	 * Setter for payer_id
-	 * @param string $payer_id
-	 */ 
-	public function setPayer_id($payer_id) {
-		$this->payer_id = $payer_id;
-	}
+    /**
+     * Getter for payer_id
+     */
+    public function getPayer_id() {
+        return $this->payer_id;
+    }
 
-	/**
-	 * Getter for payer_id
-	 */ 
-	public function getPayer_id() {
-		return $this->payer_id;
-	}
+    /**
+     * Setter for shipping_address
+     * @param PayPal\Api\Address $shipping_address
+     */
+    public function setShipping_address($shipping_address) {
+        $this->shipping_address = $shipping_address;
+        return $this;
+    }
 
-	/**
-	 * Setter for shipping_address
-	 * @param PayPal\Api\Address $shipping_address
-	 */ 
-	public function setShipping_address($shipping_address) {
-		$this->shipping_address = $shipping_address;
-	}
+    /**
+     * Getter for shipping_address
+     */
+    public function getShipping_address() {
+        return $this->shipping_address;
+    }
 
-	/**
-	 * Getter for shipping_address
-	 */ 
-	public function getShipping_address() {
-		return $this->shipping_address;
-	}
+    /**
+     * Setter for phone
+     * @param string $phone
+     */
+    public function setPhone($phone) {
+        $this->phone = $phone;
+        return $this;
+    }
 
-	/**
-	 * Setter for phone
-	 * @param string $phone
-	 */ 
-	public function setPhone($phone) {
-		$this->phone = $phone;
-	}
-
-	/**
-	 * Getter for phone
-	 */ 
-	public function getPhone() {
-		return $this->phone;
-	}
-
+    /**
+     * Getter for phone
+     */
+    public function getPhone() {
+        return $this->phone;
+    }
 
 }

--- a/lib/PayPal/Api/Payment.php
+++ b/lib/PayPal/Api/Payment.php
@@ -1,6 +1,7 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
+
 use PayPal\Rest\IResource;
 use PayPal\Rest\Call;
 use PayPal\Rest\ApiContext;
@@ -10,235 +11,241 @@ use PayPal\Rest\ApiContext;
  */
 class Payment extends Resource implements IResource {
 
-	private static $credential;
-	
-	public static function setCredential($credential) {
-		self::$credential = $credential;
-	}
-	
-	/**
-	 * Setter for id
-	 * @param string $id
-	 */ 
-	public function setId($id) {
-		$this->id = $id;
-	}
+    private static $credential;
 
-	/**
-	 * Getter for id
-	 */ 
-	public function getId() {
-		return $this->id;
-	}
+    public static function setCredential($credential) {
+        self::$credential = $credential;
+    }
 
-	/**
-	 * Setter for create_time
-	 * @param string $create_time
-	 */ 
-	public function setCreate_time($create_time) {
-		$this->create_time = $create_time;
-	}
+    /**
+     * Setter for id
+     * @param string $id
+     */
+    public function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
 
-	/**
-	 * Getter for create_time
-	 */ 
-	public function getCreate_time() {
-		return $this->create_time;
-	}
+    /**
+     * Getter for id
+     */
+    public function getId() {
+        return $this->id;
+    }
 
-	/**
-	 * Setter for update_time
-	 * @param string $update_time
-	 */ 
-	public function setUpdate_time($update_time) {
-		$this->update_time = $update_time;
-	}
+    /**
+     * Setter for create_time
+     * @param string $create_time
+     */
+    public function setCreate_time($create_time) {
+        $this->create_time = $create_time;
+        return $this;
+    }
 
-	/**
-	 * Getter for update_time
-	 */ 
-	public function getUpdate_time() {
-		return $this->update_time;
-	}
+    /**
+     * Getter for create_time
+     */
+    public function getCreate_time() {
+        return $this->create_time;
+    }
 
-	/**
-	 * Setter for state
-	 * @param string $state
-	 */ 
-	public function setState($state) {
-		$this->state = $state;
-	}
+    /**
+     * Setter for update_time
+     * @param string $update_time
+     */
+    public function setUpdate_time($update_time) {
+        $this->update_time = $update_time;
+        return $this;
+    }
 
-	/**
-	 * Getter for state
-	 */ 
-	public function getState() {
-		return $this->state;
-	}
+    /**
+     * Getter for update_time
+     */
+    public function getUpdate_time() {
+        return $this->update_time;
+    }
 
-	/**
-	 * Setter for intent
-	 * @param string $intent
-	 */ 
-	public function setIntent($intent) {
-		$this->intent = $intent;
-	}
+    /**
+     * Setter for state
+     * @param string $state
+     */
+    public function setState($state) {
+        $this->state = $state;
+        return $this;
+    }
 
-	/**
-	 * Getter for intent
-	 */ 
-	public function getIntent() {
-		return $this->intent;
-	}
+    /**
+     * Getter for state
+     */
+    public function getState() {
+        return $this->state;
+    }
 
-	/**
-	 * Setter for payer
-	 * @param PayPal\Api\Payer $payer
-	 */ 
-	public function setPayer($payer) {
-		$this->payer = $payer;
-	}
+    /**
+     * Setter for intent
+     * @param string $intent
+     */
+    public function setIntent($intent) {
+        $this->intent = $intent;
+        return $this;
+    }
 
-	/**
-	 * Getter for payer
-	 */ 
-	public function getPayer() {
-		return $this->payer;
-	}
+    /**
+     * Getter for intent
+     */
+    public function getIntent() {
+        return $this->intent;
+    }
 
-	/**
-	 * Setter for transactions
-	 * @param PayPal\Api\Transaction $transactions
-	 */ 
-	public function setTransactions($transactions) {
-		$this->transactions = $transactions;
-	}
+    /**
+     * Setter for payer
+     * @param PayPal\Api\Payer $payer
+     */
+    public function setPayer($payer) {
+        $this->payer = $payer;
+        return $this;
+    }
 
-	/**
-	 * Getter for transactions
-	 */ 
-	public function getTransactions() {
-		return $this->transactions;
-	}
+    /**
+     * Getter for payer
+     */
+    public function getPayer() {
+        return $this->payer;
+    }
 
-	/**
-	 * Setter for redirect_urls
-	 * @param PayPal\Api\RedirectUrls $redirect_urls
-	 */ 
-	public function setRedirect_urls($redirect_urls) {
-		$this->redirect_urls = $redirect_urls;
-	}
+    /**
+     * Setter for transactions
+     * @param PayPal\Api\Transaction $transactions
+     */
+    public function setTransactions($transactions) {
+        $this->transactions = $transactions;
+        return $this;
+    }
 
-	/**
-	 * Getter for redirect_urls
-	 */ 
-	public function getRedirect_urls() {
-		return $this->redirect_urls;
-	}
+    /**
+     * Getter for transactions
+     */
+    public function getTransactions() {
+        return $this->transactions;
+    }
 
-	/**
-	 * Setter for links
-	 * @param PayPal\Api\Link $links
-	 */ 
-	public function setLinks($links) {
-		$this->links = $links;
-	}
+    /**
+     * Setter for redirect_urls
+     * @param PayPal\Api\RedirectUrls $redirect_urls
+     */
+    public function setRedirect_urls($redirect_urls) {
+        $this->redirect_urls = $redirect_urls;
+        return $this;
+    }
 
-	/**
-	 * Getter for links
-	 */ 
-	public function getLinks() {
-		return $this->links;
-	}
+    /**
+     * Getter for redirect_urls
+     */
+    public function getRedirect_urls() {
+        return $this->redirect_urls;
+    }
 
-	
-	
-	/**
-	 * @path /v1/payments/payment
-	 * @method GET
-	 * @param array $params
-	 *			array containing the query strings with the 
-	 *			following values as keys:
-	 *			count,
-	 *			start_id,
-	 *			start_index,
-	 *			start_time,
-	 *			end_time,
-	 *			payee_id,
-	 *			sort_by,
-	 *			sort_order,
-	 *			All other keys in the map are ignored by the SDK	  	 
-	 */
-	public static function all($params) {
-		$payLoad = "";
-		$allowedParams = array('count' => 1, 'start_id' => 1, 'start_index' => 1, 'start_time' => 1, 'end_time' => 1, 'payee_id' => 1, 'sort_by' => 1, 'sort_order' => 1, );		
-		
-		$apiContext = new ApiContext(self::$credential);		$call = new Call();		
-		$json = $call->execute("/v1/payments/payment?" . http_build_query(array_intersect_key($params, $allowedParams)), "GET", $payLoad, $apiContext);
-		$ret = new PaymentHistory();
-		$ret->fromJson($json);
-		return $ret;
- 		 		
- 	}
-	
-	/**
-	 * @path /v1/payments/payment
-	 * @method POST
-	  
-	 * @param PayPal\Rest\ApiContext $apiContext optional	  	 
-	 */
-	public function create( $apiContext=null) {
-		$payLoad = $this->toJSON();	
-		if($apiContext == null) {
-			$apiContext = new ApiContext(self::$credential);
-		}
-		$call = new Call();		
-		$json = $call->execute("/v1/payments/payment", "POST", $payLoad, $apiContext);
-		$this->fromJson($json);
- 		return $this; 		
- 	}
-	
-	/**
-	 * @path /v1/payments/payment/:payment-id
-	 * @method GET
-	 * @param string $paymentid	  	 
-	 */
-	public static function get( $paymentid) {
-		if (($paymentid == null) || (strlen($paymentid) <= 0)) {
-			throw new \InvalidArgumentException("paymentid cannot be null or empty");
-		}
-		$payLoad = "";
-		
-		$apiContext = new ApiContext(self::$credential);		$call = new Call();		
-		$json = $call->execute("/v1/payments/payment/$paymentid", "GET", $payLoad, $apiContext);
-		$ret = new Payment();
-		$ret->fromJson($json);
-		return $ret;
- 		 		
- 	}
-	
-	/**
-	 * @path /v1/payments/payment/:payment-id/execute
-	 * @method POST
-	 * @param PaymentExecution $payment_execution	  
-	 * @param PayPal\Rest\ApiContext $apiContext optional	  	 
-	 */
-	public function execute( $payment_execution, $apiContext=null) {
-		if ($payment_execution == null) {
-			throw new \InvalidArgumentException("payment_execution cannot be null");
-		}
-		if ($this->getId() == null) {
-			throw new \InvalidArgumentException("Id cannot be null");
-		}
-		$payLoad = $payment_execution->toJSON();	
-		if($apiContext == null) {
-			$apiContext = new ApiContext(self::$credential);
-		}
-		$call = new Call();		
-		$json = $call->execute("/v1/payments/payment/{$this->getId()}/execute", "POST", $payLoad, $apiContext);
-		$this->fromJson($json);
- 		return $this; 		
- 	}
-	
+    /**
+     * Setter for links
+     * @param PayPal\Api\Link $links
+     */
+    public function setLinks($links) {
+        $this->links = $links;
+        return $this;
+    }
+
+    /**
+     * Getter for links
+     */
+    public function getLinks() {
+        return $this->links;
+    }
+
+    /**
+     * @path /v1/payments/payment
+     * @method GET
+     * @param array $params
+     * 			array containing the query strings with the 
+     * 			following values as keys:
+     * 			count,
+     * 			start_id,
+     * 			start_index,
+     * 			start_time,
+     * 			end_time,
+     * 			payee_id,
+     * 			sort_by,
+     * 			sort_order,
+     * 			All other keys in the map are ignored by the SDK	  	 
+     */
+    public static function all($params) {
+        $payLoad = "";
+        $allowedParams = array('count' => 1, 'start_id' => 1, 'start_index' => 1, 'start_time' => 1, 'end_time' => 1, 'payee_id' => 1, 'sort_by' => 1, 'sort_order' => 1,);
+
+        $apiContext = new ApiContext(self::$credential);
+        $call = new Call();
+        $json = $call->execute("/v1/payments/payment?" . http_build_query(array_intersect_key($params, $allowedParams)), "GET", $payLoad, $apiContext);
+        $ret = new PaymentHistory();
+        $ret->fromJson($json);
+        return $ret;
+    }
+
+    /**
+     * @path /v1/payments/payment
+     * @method POST
+
+     * @param PayPal\Rest\ApiContext $apiContext optional	  	 
+     */
+    public function create($apiContext = null) {
+        $payLoad = $this->toJSON();
+        if ($apiContext == null) {
+            $apiContext = new ApiContext(self::$credential);
+        }
+        $call = new Call();
+        $json = $call->execute("/v1/payments/payment", "POST", $payLoad, $apiContext);
+        $this->fromJson($json);
+        return $this;
+    }
+
+    /**
+     * @path /v1/payments/payment/:payment-id
+     * @method GET
+     * @param string $paymentid	  	 
+     */
+    public static function get($paymentid) {
+        if (($paymentid == null) || (strlen($paymentid) <= 0)) {
+            throw new \InvalidArgumentException("paymentid cannot be null or empty");
+        }
+        $payLoad = "";
+
+        $apiContext = new ApiContext(self::$credential);
+        $call = new Call();
+        $json = $call->execute("/v1/payments/payment/$paymentid", "GET", $payLoad, $apiContext);
+        $ret = new Payment();
+        $ret->fromJson($json);
+        return $ret;
+    }
+
+    /**
+     * @path /v1/payments/payment/:payment-id/execute
+     * @method POST
+     * @param PaymentExecution $payment_execution	  
+     * @param PayPal\Rest\ApiContext $apiContext optional	  	 
+     */
+    public function execute($payment_execution, $apiContext = null) {
+        if ($payment_execution == null) {
+            throw new \InvalidArgumentException("payment_execution cannot be null");
+        }
+        if ($this->getId() == null) {
+            throw new \InvalidArgumentException("Id cannot be null");
+        }
+        $payLoad = $payment_execution->toJSON();
+        if ($apiContext == null) {
+            $apiContext = new ApiContext(self::$credential);
+        }
+        $call = new Call();
+        $json = $call->execute("/v1/payments/payment/{$this->getId()}/execute", "POST", $payLoad, $apiContext);
+        $this->fromJson($json);
+        return $this;
+    }
 
 }

--- a/lib/PayPal/Api/PaymentExecution.php
+++ b/lib/PayPal/Api/PaymentExecution.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,36 +7,36 @@ namespace PayPal\Api;
  */
 class PaymentExecution extends Resource {
 
+    /**
+     * Setter for payer_id
+     * @param string $payer_id
+     */
+    public function setPayer_id($payer_id) {
+        $this->payer_id = $payer_id;
+        return $this;
+    }
 
-	/**
-	 * Setter for payer_id
-	 * @param string $payer_id
-	 */ 
-	public function setPayer_id($payer_id) {
-		$this->payer_id = $payer_id;
-	}
+    /**
+     * Getter for payer_id
+     */
+    public function getPayer_id() {
+        return $this->payer_id;
+    }
 
-	/**
-	 * Getter for payer_id
-	 */ 
-	public function getPayer_id() {
-		return $this->payer_id;
-	}
+    /**
+     * Setter for transactions
+     * @param PayPal\Api\Amount $transactions
+     */
+    public function setTransactions($transactions) {
+        $this->transactions = $transactions;
+        return $this;
+    }
 
-	/**
-	 * Setter for transactions
-	 * @param PayPal\Api\Amount $transactions
-	 */ 
-	public function setTransactions($transactions) {
-		$this->transactions = $transactions;
-	}
-
-	/**
-	 * Getter for transactions
-	 */ 
-	public function getTransactions() {
-		return $this->transactions;
-	}
-
+    /**
+     * Getter for transactions
+     */
+    public function getTransactions() {
+        return $this->transactions;
+    }
 
 }

--- a/lib/PayPal/Api/PaymentHistory.php
+++ b/lib/PayPal/Api/PaymentHistory.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,51 +7,52 @@ namespace PayPal\Api;
  */
 class PaymentHistory extends Resource {
 
+    /**
+     * Setter for payments
+     * @param PayPal\Api\Payment $payments
+     */
+    public function setPayments($payments) {
+        $this->payments = $payments;
+        return $this;
+    }
 
-	/**
-	 * Setter for payments
-	 * @param PayPal\Api\Payment $payments
-	 */ 
-	public function setPayments($payments) {
-		$this->payments = $payments;
-	}
+    /**
+     * Getter for payments
+     */
+    public function getPayments() {
+        return $this->payments;
+    }
 
-	/**
-	 * Getter for payments
-	 */ 
-	public function getPayments() {
-		return $this->payments;
-	}
+    /**
+     * Setter for count
+     * @param integer $count
+     */
+    public function setCount($count) {
+        $this->count = $count;
+        return $this;
+    }
 
-	/**
-	 * Setter for count
-	 * @param integer $count
-	 */ 
-	public function setCount($count) {
-		$this->count = $count;
-	}
+    /**
+     * Getter for count
+     */
+    public function getCount() {
+        return $this->count;
+    }
 
-	/**
-	 * Getter for count
-	 */ 
-	public function getCount() {
-		return $this->count;
-	}
+    /**
+     * Setter for next_id
+     * @param string $next_id
+     */
+    public function setNext_id($next_id) {
+        $this->next_id = $next_id;
+        return $this;
+    }
 
-	/**
-	 * Setter for next_id
-	 * @param string $next_id
-	 */ 
-	public function setNext_id($next_id) {
-		$this->next_id = $next_id;
-	}
-
-	/**
-	 * Getter for next_id
-	 */ 
-	public function getNext_id() {
-		return $this->next_id;
-	}
-
+    /**
+     * Getter for next_id
+     */
+    public function getNext_id() {
+        return $this->next_id;
+    }
 
 }

--- a/lib/PayPal/Api/RedirectUrls.php
+++ b/lib/PayPal/Api/RedirectUrls.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,36 +7,36 @@ namespace PayPal\Api;
  */
 class RedirectUrls extends Resource {
 
+    /**
+     * Setter for return_url
+     * @param string $return_url
+     */
+    public function setReturn_url($return_url) {
+        $this->return_url = $return_url;
+        return $this;
+    }
 
-	/**
-	 * Setter for return_url
-	 * @param string $return_url
-	 */ 
-	public function setReturn_url($return_url) {
-		$this->return_url = $return_url;
-	}
+    /**
+     * Getter for return_url
+     */
+    public function getReturn_url() {
+        return $this->return_url;
+    }
 
-	/**
-	 * Getter for return_url
-	 */ 
-	public function getReturn_url() {
-		return $this->return_url;
-	}
+    /**
+     * Setter for cancel_url
+     * @param string $cancel_url
+     */
+    public function setCancel_url($cancel_url) {
+        $this->cancel_url = $cancel_url;
+        return $this;
+    }
 
-	/**
-	 * Setter for cancel_url
-	 * @param string $cancel_url
-	 */ 
-	public function setCancel_url($cancel_url) {
-		$this->cancel_url = $cancel_url;
-	}
-
-	/**
-	 * Getter for cancel_url
-	 */ 
-	public function getCancel_url() {
-		return $this->cancel_url;
-	}
-
+    /**
+     * Getter for cancel_url
+     */
+    public function getCancel_url() {
+        return $this->cancel_url;
+    }
 
 }

--- a/lib/PayPal/Api/Refund.php
+++ b/lib/PayPal/Api/Refund.php
@@ -1,6 +1,7 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
+
 use PayPal\Rest\IResource;
 use PayPal\Rest\Call;
 use PayPal\Rest\ApiContext;
@@ -10,182 +11,189 @@ use PayPal\Rest\ApiContext;
  */
 class Refund extends Resource implements IResource {
 
-	private static $credential;
-	
-	public static function setCredential($credential) {
-		self::$credential = $credential;
-	}
-	
-	/**
-	 * Setter for id
-	 * @param string $id
-	 */ 
-	public function setId($id) {
-		$this->id = $id;
-	}
+    private static $credential;
 
-	/**
-	 * Getter for id
-	 */ 
-	public function getId() {
-		return $this->id;
-	}
+    public static function setCredential($credential) {
+        self::$credential = $credential;
+    }
 
-	/**
-	 * Setter for create_time
-	 * @param string $create_time
-	 */ 
-	public function setCreate_time($create_time) {
-		$this->create_time = $create_time;
-	}
+    /**
+     * Setter for id
+     * @param string $id
+     */
+    public function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
 
-	/**
-	 * Getter for create_time
-	 */ 
-	public function getCreate_time() {
-		return $this->create_time;
-	}
+    /**
+     * Getter for id
+     */
+    public function getId() {
+        return $this->id;
+    }
 
-	/**
-	 * Setter for update_time
-	 * @param string $update_time
-	 */ 
-	public function setUpdate_time($update_time) {
-		$this->update_time = $update_time;
-	}
+    /**
+     * Setter for create_time
+     * @param string $create_time
+     */
+    public function setCreate_time($create_time) {
+        $this->create_time = $create_time;
+        return $this;
+    }
 
-	/**
-	 * Getter for update_time
-	 */ 
-	public function getUpdate_time() {
-		return $this->update_time;
-	}
+    /**
+     * Getter for create_time
+     */
+    public function getCreate_time() {
+        return $this->create_time;
+    }
 
-	/**
-	 * Setter for state
-	 * @param string $state
-	 */ 
-	public function setState($state) {
-		$this->state = $state;
-	}
+    /**
+     * Setter for update_time
+     * @param string $update_time
+     */
+    public function setUpdate_time($update_time) {
+        $this->update_time = $update_time;
+        return $this;
+    }
 
-	/**
-	 * Getter for state
-	 */ 
-	public function getState() {
-		return $this->state;
-	}
+    /**
+     * Getter for update_time
+     */
+    public function getUpdate_time() {
+        return $this->update_time;
+    }
 
-	/**
-	 * Setter for amount
-	 * @param PayPal\Api\Amount $amount
-	 */ 
-	public function setAmount($amount) {
-		$this->amount = $amount;
-	}
+    /**
+     * Setter for state
+     * @param string $state
+     */
+    public function setState($state) {
+        $this->state = $state;
+        return $this;
+    }
 
-	/**
-	 * Getter for amount
-	 */ 
-	public function getAmount() {
-		return $this->amount;
-	}
+    /**
+     * Getter for state
+     */
+    public function getState() {
+        return $this->state;
+    }
 
-	/**
-	 * Setter for sale_id
-	 * @param string $sale_id
-	 */ 
-	public function setSale_id($sale_id) {
-		$this->sale_id = $sale_id;
-	}
+    /**
+     * Setter for amount
+     * @param PayPal\Api\Amount $amount
+     */
+    public function setAmount($amount) {
+        $this->amount = $amount;
+        return $this;
+    }
 
-	/**
-	 * Getter for sale_id
-	 */ 
-	public function getSale_id() {
-		return $this->sale_id;
-	}
+    /**
+     * Getter for amount
+     */
+    public function getAmount() {
+        return $this->amount;
+    }
 
-	/**
-	 * Setter for capture_id
-	 * @param string $capture_id
-	 */ 
-	public function setCapture_id($capture_id) {
-		$this->capture_id = $capture_id;
-	}
+    /**
+     * Setter for sale_id
+     * @param string $sale_id
+     */
+    public function setSale_id($sale_id) {
+        $this->sale_id = $sale_id;
+        return $this;
+    }
 
-	/**
-	 * Getter for capture_id
-	 */ 
-	public function getCapture_id() {
-		return $this->capture_id;
-	}
+    /**
+     * Getter for sale_id
+     */
+    public function getSale_id() {
+        return $this->sale_id;
+    }
 
-	/**
-	 * Setter for parent_payment
-	 * @param string $parent_payment
-	 */ 
-	public function setParent_payment($parent_payment) {
-		$this->parent_payment = $parent_payment;
-	}
+    /**
+     * Setter for capture_id
+     * @param string $capture_id
+     */
+    public function setCapture_id($capture_id) {
+        $this->capture_id = $capture_id;
+        return $this;
+    }
 
-	/**
-	 * Getter for parent_payment
-	 */ 
-	public function getParent_payment() {
-		return $this->parent_payment;
-	}
+    /**
+     * Getter for capture_id
+     */
+    public function getCapture_id() {
+        return $this->capture_id;
+    }
 
-	/**
-	 * Setter for description
-	 * @param string $description
-	 */ 
-	public function setDescription($description) {
-		$this->description = $description;
-	}
+    /**
+     * Setter for parent_payment
+     * @param string $parent_payment
+     */
+    public function setParent_payment($parent_payment) {
+        $this->parent_payment = $parent_payment;
+        return $this;
+    }
 
-	/**
-	 * Getter for description
-	 */ 
-	public function getDescription() {
-		return $this->description;
-	}
+    /**
+     * Getter for parent_payment
+     */
+    public function getParent_payment() {
+        return $this->parent_payment;
+    }
 
-	/**
-	 * Setter for links
-	 * @param PayPal\Api\Link $links
-	 */ 
-	public function setLinks($links) {
-		$this->links = $links;
-	}
+    /**
+     * Setter for description
+     * @param string $description
+     */
+    public function setDescription($description) {
+        $this->description = $description;
+        return $this;
+    }
 
-	/**
-	 * Getter for links
-	 */ 
-	public function getLinks() {
-		return $this->links;
-	}
+    /**
+     * Getter for description
+     */
+    public function getDescription() {
+        return $this->description;
+    }
 
-	
-	
-	/**
-	 * @path /v1/payments/refund/:refund-id
-	 * @method GET
-	 * @param string $refundid	  	 
-	 */
-	public static function get( $refundid) {
-		if (($refundid == null) || (strlen($refundid) <= 0)) {
-			throw new \InvalidArgumentException("refundid cannot be null or empty");
-		}
-		$payLoad = "";
-		
-		$apiContext = new ApiContext(self::$credential);		$call = new Call();		
-		$json = $call->execute("/v1/payments/refund/$refundid", "GET", $payLoad, $apiContext);
-		$ret = new Refund();
-		$ret->fromJson($json);
-		return $ret;
- 		 		
- 	}
-	
+    /**
+     * Setter for links
+     * @param PayPal\Api\Link $links
+     */
+    public function setLinks($links) {
+        $this->links = $links;
+        return $this;
+    }
+
+    /**
+     * Getter for links
+     */
+    public function getLinks() {
+        return $this->links;
+    }
+
+    /**
+     * @path /v1/payments/refund/:refund-id
+     * @method GET
+     * @param string $refundid	  	 
+     */
+    public static function get($refundid) {
+        if (($refundid == null) || (strlen($refundid) <= 0)) {
+            throw new \InvalidArgumentException("refundid cannot be null or empty");
+        }
+        $payLoad = "";
+
+        $apiContext = new ApiContext(self::$credential);
+        $call = new Call();
+        $json = $call->execute("/v1/payments/refund/$refundid", "GET", $payLoad, $apiContext);
+        $ret = new Refund();
+        $ret->fromJson($json);
+        return $ret;
+    }
 
 }

--- a/lib/PayPal/Api/Sale.php
+++ b/lib/PayPal/Api/Sale.php
@@ -1,6 +1,7 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
+
 use PayPal\Rest\IResource;
 use PayPal\Rest\Call;
 use PayPal\Rest\ApiContext;
@@ -10,160 +11,164 @@ use PayPal\Rest\ApiContext;
  */
 class Sale extends Resource implements IResource {
 
-	private static $credential;
-	
-	public static function setCredential($credential) {
-		self::$credential = $credential;
-	}
-	
-	/**
-	 * Setter for id
-	 * @param string $id
-	 */ 
-	public function setId($id) {
-		$this->id = $id;
-	}
+    private static $credential;
 
-	/**
-	 * Getter for id
-	 */ 
-	public function getId() {
-		return $this->id;
-	}
+    public static function setCredential($credential) {
+        self::$credential = $credential;
+    }
 
-	/**
-	 * Setter for create_time
-	 * @param string $create_time
-	 */ 
-	public function setCreate_time($create_time) {
-		$this->create_time = $create_time;
-	}
+    /**
+     * Setter for id
+     * @param string $id
+     */
+    public function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
 
-	/**
-	 * Getter for create_time
-	 */ 
-	public function getCreate_time() {
-		return $this->create_time;
-	}
+    /**
+     * Getter for id
+     */
+    public function getId() {
+        return $this->id;
+    }
 
-	/**
-	 * Setter for update_time
-	 * @param string $update_time
-	 */ 
-	public function setUpdate_time($update_time) {
-		$this->update_time = $update_time;
-	}
+    /**
+     * Setter for create_time
+     * @param string $create_time
+     */
+    public function setCreate_time($create_time) {
+        $this->create_time = $create_time;
+        return $this;
+    }
 
-	/**
-	 * Getter for update_time
-	 */ 
-	public function getUpdate_time() {
-		return $this->update_time;
-	}
+    /**
+     * Getter for create_time
+     */
+    public function getCreate_time() {
+        return $this->create_time;
+    }
 
-	/**
-	 * Setter for state
-	 * @param string $state
-	 */ 
-	public function setState($state) {
-		$this->state = $state;
-	}
+    /**
+     * Setter for update_time
+     * @param string $update_time
+     */
+    public function setUpdate_time($update_time) {
+        $this->update_time = $update_time;
+        return $this;
+    }
 
-	/**
-	 * Getter for state
-	 */ 
-	public function getState() {
-		return $this->state;
-	}
+    /**
+     * Getter for update_time
+     */
+    public function getUpdate_time() {
+        return $this->update_time;
+    }
 
-	/**
-	 * Setter for amount
-	 * @param PayPal\Api\Amount $amount
-	 */ 
-	public function setAmount($amount) {
-		$this->amount = $amount;
-	}
+    /**
+     * Setter for state
+     * @param string $state
+     */
+    public function setState($state) {
+        $this->state = $state;
+        return $this;
+    }
 
-	/**
-	 * Getter for amount
-	 */ 
-	public function getAmount() {
-		return $this->amount;
-	}
+    /**
+     * Getter for state
+     */
+    public function getState() {
+        return $this->state;
+    }
 
-	/**
-	 * Setter for parent_payment
-	 * @param string $parent_payment
-	 */ 
-	public function setParent_payment($parent_payment) {
-		$this->parent_payment = $parent_payment;
-	}
+    /**
+     * Setter for amount
+     * @param PayPal\Api\Amount $amount
+     */
+    public function setAmount($amount) {
+        $this->amount = $amount;
+        return $this;
+    }
 
-	/**
-	 * Getter for parent_payment
-	 */ 
-	public function getParent_payment() {
-		return $this->parent_payment;
-	}
+    /**
+     * Getter for amount
+     */
+    public function getAmount() {
+        return $this->amount;
+    }
 
-	/**
-	 * Setter for links
-	 * @param PayPal\Api\Link $links
-	 */ 
-	public function setLinks($links) {
-		$this->links = $links;
-	}
+    /**
+     * Setter for parent_payment
+     * @param string $parent_payment
+     */
+    public function setParent_payment($parent_payment) {
+        $this->parent_payment = $parent_payment;
+        return $this;
+    }
 
-	/**
-	 * Getter for links
-	 */ 
-	public function getLinks() {
-		return $this->links;
-	}
+    /**
+     * Getter for parent_payment
+     */
+    public function getParent_payment() {
+        return $this->parent_payment;
+    }
 
-	
-	
-	/**
-	 * @path /v1/payments/sale/:sale-id
-	 * @method GET
-	 * @param string $saleid	  	 
-	 */
-	public static function get( $saleid) {
-		if (($saleid == null) || (strlen($saleid) <= 0)) {
-			throw new \InvalidArgumentException("saleid cannot be null or empty");
-		}
-		$payLoad = "";
-		
-		$apiContext = new ApiContext(self::$credential);		$call = new Call();		
-		$json = $call->execute("/v1/payments/sale/$saleid", "GET", $payLoad, $apiContext);
-		$ret = new Sale();
-		$ret->fromJson($json);
-		return $ret;
- 		 		
- 	}
-	
-	/**
-	 * @path /v1/payments/sale/:sale-id/refund
-	 * @method POST
-	 * @param Refund $refund	  
-	 * @param PayPal\Rest\ApiContext $apiContext optional	  	 
-	 */
-	public function refund( $refund, $apiContext=null) {
-		if ($refund == null) {
-			throw new \InvalidArgumentException("refund cannot be null");
-		}
-		if ($this->getId() == null) {
-			throw new \InvalidArgumentException("Id cannot be null");
-		}
-		$payLoad = $refund->toJSON();	
-		if($apiContext == null) {
-			$apiContext = new ApiContext(self::$credential);
-		}
-		$call = new Call();		
-		$json = $call->execute("/v1/payments/sale/{$this->getId()}/refund", "POST", $payLoad, $apiContext);
-		$this->fromJson($json);
- 		return $this; 		
- 	}
-	
+    /**
+     * Setter for links
+     * @param PayPal\Api\Link $links
+     */
+    public function setLinks($links) {
+        $this->links = $links;
+        return $this;
+    }
+
+    /**
+     * Getter for links
+     */
+    public function getLinks() {
+        return $this->links;
+    }
+
+    /**
+     * @path /v1/payments/sale/:sale-id
+     * @method GET
+     * @param string $saleid	  	 
+     */
+    public static function get($saleid) {
+        if (($saleid == null) || (strlen($saleid) <= 0)) {
+            throw new \InvalidArgumentException("saleid cannot be null or empty");
+        }
+        $payLoad = "";
+
+        $apiContext = new ApiContext(self::$credential);
+        $call = new Call();
+        $json = $call->execute("/v1/payments/sale/$saleid", "GET", $payLoad, $apiContext);
+        $ret = new Sale();
+        $ret->fromJson($json);
+        return $ret;
+    }
+
+    /**
+     * @path /v1/payments/sale/:sale-id/refund
+     * @method POST
+     * @param Refund $refund	  
+     * @param PayPal\Rest\ApiContext $apiContext optional	  	 
+     */
+    public function refund($refund, $apiContext = null) {
+        if ($refund == null) {
+            throw new \InvalidArgumentException("refund cannot be null");
+        }
+        if ($this->getId() == null) {
+            throw new \InvalidArgumentException("Id cannot be null");
+        }
+        $payLoad = $refund->toJSON();
+        if ($apiContext == null) {
+            $apiContext = new ApiContext(self::$credential);
+        }
+        $call = new Call();
+        $json = $call->execute("/v1/payments/sale/{$this->getId()}/refund", "POST", $payLoad, $apiContext);
+        $this->fromJson($json);
+        return $this;
+    }
 
 }

--- a/lib/PayPal/Api/ShippingAddress.php
+++ b/lib/PayPal/Api/ShippingAddress.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,21 +7,20 @@ namespace PayPal\Api;
  */
 class ShippingAddress extends Address {
 
+    /**
+     * Setter for recipient_name
+     * @param string $recipient_name
+     */
+    public function setRecipient_name($recipient_name) {
+        $this->recipient_name = $recipient_name;
+        return $this;
+    }
 
-	/**
-	 * Setter for recipient_name
-	 * @param string $recipient_name
-	 */ 
-	public function setRecipient_name($recipient_name) {
-		$this->recipient_name = $recipient_name;
-	}
-
-	/**
-	 * Getter for recipient_name
-	 */ 
-	public function getRecipient_name() {
-		return $this->recipient_name;
-	}
-
+    /**
+     * Getter for recipient_name
+     */
+    public function getRecipient_name() {
+        return $this->recipient_name;
+    }
 
 }

--- a/lib/PayPal/Api/SubTransaction.php
+++ b/lib/PayPal/Api/SubTransaction.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,66 +7,68 @@ namespace PayPal\Api;
  */
 class SubTransaction extends Resource {
 
+    /**
+     * Setter for sale
+     * @param PayPal\Api\Sale $sale
+     */
+    public function setSale($sale) {
+        $this->sale = $sale;
+        return $this;
+    }
 
-	/**
-	 * Setter for sale
-	 * @param PayPal\Api\Sale $sale
-	 */ 
-	public function setSale($sale) {
-		$this->sale = $sale;
-	}
+    /**
+     * Getter for sale
+     */
+    public function getSale() {
+        return $this->sale;
+    }
 
-	/**
-	 * Getter for sale
-	 */ 
-	public function getSale() {
-		return $this->sale;
-	}
+    /**
+     * Setter for authorization
+     * @param PayPal\Api\Authorization $authorization
+     */
+    public function setAuthorization($authorization) {
+        $this->authorization = $authorization;
+        return $this;
+    }
 
-	/**
-	 * Setter for authorization
-	 * @param PayPal\Api\Authorization $authorization
-	 */ 
-	public function setAuthorization($authorization) {
-		$this->authorization = $authorization;
-	}
+    /**
+     * Getter for authorization
+     */
+    public function getAuthorization() {
+        return $this->authorization;
+    }
 
-	/**
-	 * Getter for authorization
-	 */ 
-	public function getAuthorization() {
-		return $this->authorization;
-	}
+    /**
+     * Setter for refund
+     * @param PayPal\Api\Refund $refund
+     */
+    public function setRefund($refund) {
+        $this->refund = $refund;
+        return $this;
+    }
 
-	/**
-	 * Setter for refund
-	 * @param PayPal\Api\Refund $refund
-	 */ 
-	public function setRefund($refund) {
-		$this->refund = $refund;
-	}
+    /**
+     * Getter for refund
+     */
+    public function getRefund() {
+        return $this->refund;
+    }
 
-	/**
-	 * Getter for refund
-	 */ 
-	public function getRefund() {
-		return $this->refund;
-	}
+    /**
+     * Setter for capture
+     * @param PayPal\Api\Capture $capture
+     */
+    public function setCapture($capture) {
+        $this->capture = $capture;
+        return $this;
+    }
 
-	/**
-	 * Setter for capture
-	 * @param PayPal\Api\Capture $capture
-	 */ 
-	public function setCapture($capture) {
-		$this->capture = $capture;
-	}
-
-	/**
-	 * Getter for capture
-	 */ 
-	public function getCapture() {
-		return $this->capture;
-	}
-
+    /**
+     * Getter for capture
+     */
+    public function getCapture() {
+        return $this->capture;
+    }
 
 }

--- a/lib/PayPal/Api/Transaction.php
+++ b/lib/PayPal/Api/Transaction.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace PayPal\Api;
 
@@ -7,81 +7,84 @@ namespace PayPal\Api;
  */
 class Transaction extends Resource {
 
+    /**
+     * Setter for amount
+     * @param PayPal\Api\Amount $amount
+     */
+    public function setAmount($amount) {
+        $this->amount = $amount;
+        return $this;
+    }
 
-	/**
-	 * Setter for amount
-	 * @param PayPal\Api\Amount $amount
-	 */ 
-	public function setAmount($amount) {
-		$this->amount = $amount;
-	}
+    /**
+     * Getter for amount
+     */
+    public function getAmount() {
+        return $this->amount;
+    }
 
-	/**
-	 * Getter for amount
-	 */ 
-	public function getAmount() {
-		return $this->amount;
-	}
+    /**
+     * Setter for payee
+     * @param PayPal\Api\Payee $payee
+     */
+    public function setPayee($payee) {
+        $this->payee = $payee;
+        return $this;
+    }
 
-	/**
-	 * Setter for payee
-	 * @param PayPal\Api\Payee $payee
-	 */ 
-	public function setPayee($payee) {
-		$this->payee = $payee;
-	}
+    /**
+     * Getter for payee
+     */
+    public function getPayee() {
+        return $this->payee;
+    }
 
-	/**
-	 * Getter for payee
-	 */ 
-	public function getPayee() {
-		return $this->payee;
-	}
+    /**
+     * Setter for description
+     * @param string $description
+     */
+    public function setDescription($description) {
+        $this->description = $description;
+        return $this;
+    }
 
-	/**
-	 * Setter for description
-	 * @param string $description
-	 */ 
-	public function setDescription($description) {
-		$this->description = $description;
-	}
+    /**
+     * Getter for description
+     */
+    public function getDescription() {
+        return $this->description;
+    }
 
-	/**
-	 * Getter for description
-	 */ 
-	public function getDescription() {
-		return $this->description;
-	}
+    /**
+     * Setter for item_list
+     * @param PayPal\Api\ItemList $item_list
+     */
+    public function setItem_list($item_list) {
+        $this->item_list = $item_list;
+        return $this;
+    }
 
-	/**
-	 * Setter for item_list
-	 * @param PayPal\Api\ItemList $item_list
-	 */ 
-	public function setItem_list($item_list) {
-		$this->item_list = $item_list;
-	}
+    /**
+     * Getter for item_list
+     */
+    public function getItem_list() {
+        return $this->item_list;
+    }
 
-	/**
-	 * Getter for item_list
-	 */ 
-	public function getItem_list() {
-		return $this->item_list;
-	}
+    /**
+     * Setter for related_resources
+     * @param PayPal\Api\SubTransaction $related_resources
+     */
+    public function setRelated_resources($related_resources) {
+        $this->related_resources = $related_resources;
+        return $this;
+    }
 
-	/**
-	 * Setter for related_resources
-	 * @param PayPal\Api\SubTransaction $related_resources
-	 */ 
-	public function setRelated_resources($related_resources) {
-		$this->related_resources = $related_resources;
-	}
-
-	/**
-	 * Getter for related_resources
-	 */ 
-	public function getRelated_resources() {
-		return $this->related_resources;
-	}
-
+    /**
+     * Getter for related_resources
+     */
+    public function getRelated_resources() {
+        return $this->related_resources;
+    }
 
 }


### PR DESCRIPTION
This allows use of 
 <pre>$payment->setPayor($payor)
->setIntent('sale')
->setTransactions(array($transactions));
</pre>

without having to call the payment variable every time.
