### PR TITLE
Add validation of Return/Cancel URL's (with test cases)

### DIFF
--- a/lib/PayPal/Api/RedirectUrls.php
+++ b/lib/PayPal/Api/RedirectUrls.php
@@ -23,6 +23,11 @@ class RedirectUrls extends PPModel
      */
     public function setReturnUrl($return_url)
     {
+        if(filter_var($return_url, FILTER_VALIDATE_URL) === false)
+        {
+            throw new \InvalidArgumentException("Return URL is not a fully qualified URL");
+        }
+
         $this->return_url = $return_url;
 
         return $this;
@@ -79,6 +84,10 @@ class RedirectUrls extends PPModel
      */
     public function setCancelUrl($cancel_url)
     {
+        if(filter_var($cancel_url, FILTER_VALIDATE_URL) === false)
+        {
+            throw new \InvalidArgumentException("Cancel URL is not a fully qualified URL");
+        }
         $this->cancel_url = $cancel_url;
 
         return $this;

--- a/tests/PayPal/Test/Api/RedirectUrlsTest.php
+++ b/tests/PayPal/Test/Api/RedirectUrlsTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace PayPal\Test\Api;
+
+use PayPal\Api\RedirectUrls;
+
+class RedirectUrlsTest extends \PHPUnit_Framework_TestCase {
+
+	public function validRedirectUrlsProvider() {
+		return array(
+			array('https://devtools-paypal.com/guide/pay_paypal/php?success=true', 'https://devtools-paypal.com/guide/pay_paypal/php?cancel=true')
+		);
+	}
+
+	public function invalidRedirectUrlsProvider() {
+		return array(
+			array('devtools-paypal.com/guide/pay_paypal/php?success=true', 'devtools-paypal.com/guide/pay_paypal/php?cancel=true')
+		);
+	}
+
+	/**
+	 * @dataProvider validRedirectUrlsProvider
+	 */
+	public function testValidRedirectUrls($return_url, $cancel_url) {
+		$redirectUrls = new RedirectUrls();
+		$redirectUrls->setReturn_url($return_url);
+		$redirectUrls->setCancel_url($cancel_url);
+
+		$this->assertEquals($return_url, $redirectUrls->getReturnUrl());
+		$this->assertEquals($cancel_url, $redirectUrls->getCancelUrl());
+	}
+
+	/**
+	 * @dataProvider invalidRedirectUrlsProvider
+	 */
+	public function testInvalidRedirectUrls($return_url, $cancel_url) {
+		$redirectUrls = new RedirectUrls();
+		$this->setExpectedException('\InvalidArgumentException');
+		$redirectUrls->setReturnUrl($return_url);
+		$redirectUrls->setCancelUrl($cancel_url);
+	}
+
+}


### PR DESCRIPTION
I recently was integrating with PayPal and during development I set my return/cancel URL's to omit the hostname (eg. `paypal.com` instead of `https://paypal.com`). This caused my request to fail with a 400 response and set me down a rabbit hole for a little bit until I realised what I'd done.

This pull request adds some basic validation to the `setReturnUrl` and `setCancelUrl` methods to check the argument is a URL (or at least looks like one). An `\InvalidArgumentException` is thrown otherwise.

I've also added the corresponding Unit Test as well as the `RedirectUrls` class is currently not covered :)
