### PR TITLE
Add description and tax properties to item object

### DIFF
--- a/lib/PayPal/Api/Item.php
+++ b/lib/PayPal/Api/Item.php
@@ -148,51 +148,51 @@ class Item extends PPModel
         return $this->sku;
     }
 
-	/**
-	 * Set Description
-	 * Description of the item
-	 *
-	 * @param string $description
-	 *
-	 * @return $this
-	 */
-	public function setDescription($description) {
-		$this->description = $description;
+    /**
+     * Set Description
+     * Description of the item
+     *
+     * @param string $description
+     *
+     * @return $this
+     */
+    public function setDescription($description) {
+        $this->description = $description;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Get Description
-	 * Description of the item
-	 *
-	 * @return string
-	 */
-	public function getDescription() {
-		return $this->description;
-	}
+    /**
+     * Get Description
+     * Description of the item
+     *
+     * @return string
+     */
+    public function getDescription() {
+        return $this->description;
+    }
 
-	/**
-	 * Set Tax
-	 * Tax of the item
-	 *
-	 * @param string $tax
-	 *
-	 * @return $this
-	 */
-	public function setTax($tax) {
-		$this->tax = $tax;
+    /**
+     * Set Tax
+     * Tax of the item
+     *
+     * @param string $tax
+     *
+     * @return $this
+     */
+    public function setTax($tax) {
+        $this->tax = $tax;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Get Tax
-	 * Tax of the item
-	 *
-	 * @return string
-	 */
-	public function getTax($tax) {
-		return $this->tax;
-	}
+    /**
+     * Get Tax
+     * Tax of the item
+     *
+     * @return string
+     */
+    public function getTax($tax) {
+        return $this->tax;
+    }
 }


### PR DESCRIPTION
Add new properties in [item object](https://developer.paypal.com/docs/api/#item-object):
1. `description`
2. `tax`

Fixes comment typo @ line 141.
