### PR TITLE
\PayPal\Api\Invoice: Added missing $headers argument in \PayPal\Common\ResourceModel::executeCall() calls

### DIFF
--- a/lib/PayPal/Api/Invoice.php
+++ b/lib/PayPal/Api/Invoice.php
@@ -846,7 +846,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices",
             "POST",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -870,7 +870,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/search",
             "POST",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -894,7 +894,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/{$this->getId()}/send",
             "POST",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -918,7 +918,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/{$this->getId()}/remind",
             "POST",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -942,7 +942,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/{$this->getId()}/cancel",
             "POST",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -966,7 +966,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/{$this->getId()}/record-payment",
             "POST",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -990,7 +990,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/{$this->getId()}/record-refund",
             "POST",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -1013,7 +1013,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/$invoiceId",
             "GET",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -1036,7 +1036,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/",
             "GET",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -1060,7 +1060,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/{$this->getId()}",
             "PUT",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );
@@ -1083,7 +1083,7 @@ class Invoice extends ResourceModel
             "/v1/invoicing/invoices/{$this->getId()}",
             "DELETE",
             $payLoad,
-            [],
+            array(),
             $apiContext,
             $restCall
         );


### PR DESCRIPTION
This fixes the error `Object of class PayPal\Rest\ApiContext could not be converted to int' in /app/vendor/paypal/rest-api-sdk-php/lib/PayPal/Transport/PPRestCall.php:63`.
