### PR TITLE
Fixes PHP 5.3 Support

### DIFF
--- a/lib/PayPal/Api/FuturePayment.php
+++ b/lib/PayPal/Api/FuturePayment.php
@@ -35,10 +35,10 @@ class FuturePayment extends Payment
             "/v1/payments/payment",
             "POST",
             $payLoad,
-            [
+            array(
                 'Paypal-Application-Correlation-Id' => $correlationId,
                 'PAYPAL-CLIENT-METADATA-ID' => $correlationId
-            ]
+            )
         );
         $this->fromJson($json);
 


### PR DESCRIPTION
Using short array syntax breaks the support of PHP 5.3 which is supported by the SDK according to it's README.

`php -l` might have caught it.
