### PR TITLE
do not escape / on create

### DIFF
--- a/lib/PayPal/Api/Payment.php
+++ b/lib/PayPal/Api/Payment.php
@@ -397,7 +397,7 @@ class Payment extends PPModel implements IResource
     public function create($apiContext = null)
     {
 
-        $payLoad = $this->toJSON();
+        $payLoad = $this->toJSON(JSON_UNESCAPED_SLASHES);
         if ($apiContext == null) {
             $apiContext = new ApiContext(self::$credential);
         }


### PR DESCRIPTION
if we specify redirect_urls (for example on payment_method = paypal) they get double json_encoded, so we get a MALFORMED_REQUEST error from api. This change avoids the wrong encoding.
