### PR TITLE
Fixing error "Class 'string' Not Found!"

### DIFF
--- a/lib/PayPal/Common/PPModel.php
+++ b/lib/PayPal/Common/PPModel.php
@@ -156,9 +156,13 @@ class PPModel
                 $clazz = PPReflectionUtil::getPropertyClass(get_class($this), $k);
                 if (PPArrayUtil::isAssocArray($v)) {
                     /** @var self $o */
-                    $o = new $clazz();
-                    $o->fromArray($v);
-                    $this->assignValue($k, $o);
+                    if($clazz == "string"){
+                        $this->assignValue($k, $v);
+                    }else{
+                        $o = new $clazz();
+                        $o->fromArray($v);
+                        $this->assignValue($k, $o);
+                    }
                 } else {
                     $arr = array();
                     foreach ($v as $nk => $nv) {


### PR DESCRIPTION
Because there is a fallback in the getPropertyClass function, which can return a 'string' then it is impossible to create a new 'string' object, therefore a fatal error is thrown.
