### PR TITLE
added transaction fee support to sale class

### DIFF
--- a/lib/PayPal/Api/Sale.php
+++ b/lib/PayPal/Api/Sale.php
@@ -2,9 +2,9 @@
 
 namespace PayPal\Api;
 
+use PayPal\Api\Refund;
 use PayPal\Common\PayPalResourceModel;
 use PayPal\Rest\ApiContext;
-use PayPal\Api\Refund;
 use PayPal\Transport\PayPalRestCall;
 use PayPal\Validation\ArgumentValidator;
 
@@ -13,7 +13,6 @@ use PayPal\Validation\ArgumentValidator;
  *
  * A sale transaction.
  *
- * @package PayPal\Api
  *
  * @property string id
  * @property string create_time
@@ -27,15 +26,31 @@ use PayPal\Validation\ArgumentValidator;
  * @property string protection_eligibility_type
  * @property string clearing_time
  * @property string parent_payment
+ * @property \PayPal\Api\TransactionFee $transactionFee
+ * @package PayPal\Api
  */
 class Sale extends PayPalResourceModel
 {
+    public function setTransactionFee(\PayPal\Api\TransactionFee $transactionFee)
+    {
+        $this->transactionFee = $transactionFee;
+        return $this;
+    }
+
+    /**
+     * @return \PayPal\Api\TransactionFee
+     */
+    public function getTransactionFee()
+    {
+        return $this->transactionFee;
+    }
+
     /**
      * Identifier of the authorization transaction.
-     * 
      *
-     * @param string $id
-     * 
+     *
+     *
+     * @param  string  $id
      * @return $this
      */
     public function setId($id)
@@ -56,10 +71,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * Time the resource was created.
-     * 
      *
-     * @param string $create_time
-     * 
+     *
+     *
+     * @param  string  $create_time
      * @return $this
      */
     public function setCreateTime($create_time)
@@ -80,10 +95,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * Time the resource was last updated.
-     * 
      *
-     * @param string $update_time
-     * 
+     *
+     *
+     * @param  string  $update_time
      * @return $this
      */
     public function setUpdateTime($update_time)
@@ -104,10 +119,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * Amount being collected.
-     * 
      *
-     * @param \PayPal\Api\Amount $amount
-     * 
+     *
+     *
+     * @param  \PayPal\Api\Amount $amount
      * @return $this
      */
     public function setAmount($amount)
@@ -128,10 +143,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * specifies payment mode of the transaction
-     * Valid Values: ["INSTANT_TRANSFER", "MANUAL_BANK_TRANSFER", "DELAYED_TRANSFER", "ECHECK"] 
+     * Valid Values: ["INSTANT_TRANSFER", "MANUAL_BANK_TRANSFER", "DELAYED_TRANSFER", "ECHECK"]
      *
-     * @param string $payment_mode
-     * 
+     *
+     * @param  string  $payment_mode
      * @return $this
      */
     public function setPaymentMode($payment_mode)
@@ -152,10 +167,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * Reason of Pending transaction.
-     * 
      *
-     * @param string $pending_reason
-     * 
+     *
+     *
+     * @param  string  $pending_reason
      * @return $this
      */
     public function setPendingReason($pending_reason)
@@ -176,10 +191,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * State of the sale transaction.
-     * Valid Values: ["pending", "completed", "refunded", "partially_refunded"] 
+     * Valid Values: ["pending", "completed", "refunded", "partially_refunded"]
      *
-     * @param string $state
-     * 
+     *
+     * @param  string  $state
      * @return $this
      */
     public function setState($state)
@@ -200,10 +215,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * Reason code for the transaction state being Pending or Reversed.
-     * Valid Values: ["CHARGEBACK", "GUARANTEE", "BUYER_COMPLAINT", "REFUND", "UNCONFIRMED_SHIPPING_ADDRESS", "ECHECK", "INTERNATIONAL_WITHDRAWAL", "RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION", "PAYMENT_REVIEW", "REGULATORY_REVIEW", "UNILATERAL", "VERIFICATION_REQUIRED"] 
+     * Valid Values: ["CHARGEBACK", "GUARANTEE", "BUYER_COMPLAINT", "REFUND", "UNCONFIRMED_SHIPPING_ADDRESS", "ECHECK", "INTERNATIONAL_WITHDRAWAL", "RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION", "PAYMENT_REVIEW", "REGULATORY_REVIEW", "UNILATERAL", "VERIFICATION_REQUIRED"]
      *
-     * @param string $reason_code
-     * 
+     *
+     * @param  string  $reason_code
      * @return $this
      */
     public function setReasonCode($reason_code)
@@ -223,11 +238,11 @@ class Sale extends PayPalResourceModel
     }
 
     /**
-     * Protection Eligibility of the Payer 
-     * Valid Values: ["ELIGIBLE", "PARTIALLY_ELIGIBLE", "INELIGIBLE"] 
+     * Protection Eligibility of the Payer
+     * Valid Values: ["ELIGIBLE", "PARTIALLY_ELIGIBLE", "INELIGIBLE"]
      *
-     * @param string $protection_eligibility
-     * 
+     *
+     * @param  string  $protection_eligibility
      * @return $this
      */
     public function setProtectionEligibility($protection_eligibility)
@@ -237,7 +252,7 @@ class Sale extends PayPalResourceModel
     }
 
     /**
-     * Protection Eligibility of the Payer 
+     * Protection Eligibility of the Payer
      *
      * @return string
      */
@@ -247,11 +262,11 @@ class Sale extends PayPalResourceModel
     }
 
     /**
-     * Protection Eligibility Type of the Payer 
-     * Valid Values: ["ELIGIBLE", "ITEM_NOT_RECEIVED_ELIGIBLE", "INELIGIBLE", "UNAUTHORIZED_PAYMENT_ELIGIBLE"] 
+     * Protection Eligibility Type of the Payer
+     * Valid Values: ["ELIGIBLE", "ITEM_NOT_RECEIVED_ELIGIBLE", "INELIGIBLE", "UNAUTHORIZED_PAYMENT_ELIGIBLE"]
      *
-     * @param string $protection_eligibility_type
-     * 
+     *
+     * @param  string  $protection_eligibility_type
      * @return $this
      */
     public function setProtectionEligibilityType($protection_eligibility_type)
@@ -261,7 +276,7 @@ class Sale extends PayPalResourceModel
     }
 
     /**
-     * Protection Eligibility Type of the Payer 
+     * Protection Eligibility Type of the Payer
      *
      * @return string
      */
@@ -272,10 +287,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * Expected clearing time for eCheck Transactions
-     * 
      *
-     * @param string $clearing_time
-     * 
+     *
+     *
+     * @param  string  $clearing_time
      * @return $this
      */
     public function setClearingTime($clearing_time)
@@ -296,10 +311,10 @@ class Sale extends PayPalResourceModel
 
     /**
      * ID of the Payment resource that this transaction is based on.
-     * 
      *
-     * @param string $parent_payment
-     * 
+     *
+     *
+     * @param  string  $parent_payment
      * @return $this
      */
     public function setParentPayment($parent_payment)
@@ -321,9 +336,9 @@ class Sale extends PayPalResourceModel
     /**
      * Obtain the Sale transaction resource for the given identifier.
      *
-     * @param string $saleId
-     * @param \PayPal\Rest\ApiContext $apiContext is the APIContext for this call. It can be used to pass dynamic configuration and credentials.
-     * @param PayPalRestCall $restCall is the Rest Call Service that is used to make rest calls
+     * @param  string                  $saleId
+     * @param  \PayPal\Rest\ApiContext $apiContext is the APIContext for this call. It can be used to pass dynamic configuration and credentials.
+     * @param  PayPalRestCall          $restCall   is the Rest Call Service that is used to make rest calls
      * @return Sale
      */
     public static function get($saleId, $apiContext = null, $restCall = null)
@@ -347,9 +362,9 @@ class Sale extends PayPalResourceModel
     /**
      * Creates (and processes) a new Refund Transaction added as a related resource.
      *
-     * @param Refund $refund
-     * @param \PayPal\Rest\ApiContext $apiContext is the APIContext for this call. It can be used to pass dynamic configuration and credentials.
-     * @param PayPalRestCall $restCall is the Rest Call Service that is used to make rest calls
+     * @param  Refund                  $refund
+     * @param  \PayPal\Rest\ApiContext $apiContext is the APIContext for this call. It can be used to pass dynamic configuration and credentials.
+     * @param  PayPalRestCall          $restCall   is the Rest Call Service that is used to make rest calls
      * @return Refund
      */
     public function refund($refund, $apiContext = null, $restCall = null)

--- a/lib/PayPal/Api/TransactionFee.php
+++ b/lib/PayPal/Api/TransactionFee.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PayPal\Api;
+
+use PayPal\Common\PayPalModel;
+use PayPal\Converter\FormatConverter;
+use PayPal\Validation\NumericValidator;
+
+/**
+ * Class TranactionFee
+ *
+ * Let's you specify details of the transaction fee.
+ *
+ * @package PayPal\Api
+ *
+ * @property string currency
+ * @property string value
+ */
+class TransactionFee extends PayPalModel
+{
+    /**
+     * 3 letter currency code
+     *
+     *
+     * @param string $currency
+     *
+     * @return $this
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+    /**
+     * 3 letter currency code
+     *
+     * @return string
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * Total amount charged from the Payer account (or card) to Payee. In case of a refund, this is the refunded amount to the original Payer from Payee account.
+     *
+     *
+     * @param string|double $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        NumericValidator::validate($value, "value");
+        $value = FormatConverter::formatToPrice($value, $this->getCurrency());
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * Value amount charged from the Payer account (or card) to Payee. In case of a refund, this is the refunded amount to the original Payer from Payee account.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/tests/PayPal/Test/Api/SaleTest.php
+++ b/tests/PayPal/Test/Api/SaleTest.php
@@ -1,19 +1,16 @@
 <?php
 namespace PayPal\Test\Api;
 
-use PayPal\Api\Refund;
 use PayPal\Api\Sale;
-use PayPal\Test\Constants;
 use PayPal\Test\Api\AmountTest;
-use PayPal\Test\Api\PaymentTest;
-use PayPal\Test\Api\LinksTest;
-use PayPal\Exception\PayPalConnectionException;
 
 class SaleTest extends \PHPUnit_Framework_TestCase
 {
-
-    /** @var  Sale */
+    /**
+     * @var Sale
+     */
     private $sale;
+    private $tFee;
 
     public static $captureId = "CAP-123";
     public static $createTime = "2013-02-28T00:00:00Z";
@@ -21,7 +18,7 @@ class SaleTest extends \PHPUnit_Framework_TestCase
     public static $parentPayment = "PAY-123";
     public static $state = "Created";
 
-    public static function createSale()
+    private function createSale()
     {
         $sale = new Sale();
         $sale->setAmount(AmountTest::createAmount());
@@ -29,12 +26,18 @@ class SaleTest extends \PHPUnit_Framework_TestCase
         $sale->setId(self::$id);
         $sale->setParentPayment(self::$parentPayment);
         $sale->setState(self::$state);
+
+        $this->tFee = new \PayPal\Api\TransactionFee();
+        $this->tFee->setCurrency('AUD');
+        $this->tFee->setValue('0.10');
+
+        $sale->setTransactionFee($this->tFee);
         return $sale;
     }
 
     public function setup()
     {
-        $this->sale = self::createSale();
+        $this->sale = $this->createSale();
     }
 
     public function testGetterSetter()
@@ -44,6 +47,7 @@ class SaleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$parentPayment, $this->sale->getParentPayment());
         $this->assertEquals(self::$state, $this->sale->getState());
         $this->assertEquals(AmountTest::$currency, $this->sale->getAmount()->getCurrency());
+        $this->assertEquals($this->tFee, $this->sale->getTransactionFee());
     }
 
     public function testSerializeDeserialize()

--- a/tests/PayPal/Test/Api/TransactionFeeTest.php
+++ b/tests/PayPal/Test/Api/TransactionFeeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PayPal\Test\Api;
+
+use PayPal\Api\TransactionFee;
+
+class TransactionFeeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetterSetter()
+    {
+        $tfee = new TransactionFee();
+        $tfee->setCurrency('AUD');
+        $this->assertEquals('AUD', $tfee->getCurrency());
+
+        $tfee->setValue('0.10');
+        $this->assertEquals('0.10', $tfee->getValue());
+    }
+}


### PR DESCRIPTION
I am raising this PR mostly for discussion while I wait for PayPal support engineers to respond.

Last week we discovered that a new "transaction_fee" element had been added to the response for a POST request to /v1/payments/payment. This causes an issue with this SDK as reflection is used to map the JSON to PHP Objects.

Problem JSON
```json
{
  "id": "PAY-2DD06538S7025641FKTHAEII",
  "create_time": "2015-02-01T02:38:26.026Z",
  "update_time": "2015-02-01T02:38:26.026Z",
  "state": "approved",
  "intent": "sale",
  "payer": {
    "payment_method": "paypal",
    "payer_info": {
      "email": "chaitanya@**********",
      "first_name": "Chaitanya",
      "last_name": "Kuber",
      "payer_id": "6RT3WYKUX89LN"
    }
  },
  "transactions": [
    {
      "amount": {
        "total": "5.00",
        "currency": "AUD",
        "details": {}
      },
      "description": "BTQ Order",
      "related_resources": [
        {
          "sale": {
            "id": "93P456876H0968255",
            "create_time": "2015-02-01T02:38:26.026Z",
            "update_time": "2015-02-01T02:38:26.026Z",
            "state": "completed",
            "amount": {
              "total": "5.00",
              "currency": "AUD"
            },
            "protection_eligibility": "ELIGIBLE",
            "protection_eligibility_type": "ITEM_NOT_RECEIVED_ELIGIBLE, UNAUTHORIZED_PAYMENT_ELIGIBLE",
            "transaction_fee": {
              "value": "0.10",
              "currency": "AUD"
            },
            "parent_payment": "PAY-2DD06538S7025641FKTHAEII",
            "links": [
              {
                "href": "https://api.paypal.com/v1/payments/sale/93P456876H0968255",
                "rel": "self",
                "method": "GET"
              },
              {
                "href": "https://api.paypal.com/v1/payments/sale/93P456876H0968255/REFUND",
                "rel": "refund",
                "method": "POST"
              },
              {
                "href": "https://api.paypal.com/v1/payments/payment/PAY-2DD06538S7025641FKTHAEII",
                "rel": "parent_payment",
                "method": "GET"
              }
            ]
          }
        }
      ]
    }
  ],
  "links": [
    {
      "href": "https://api.paypal.com/v1/payments/payment/PAY-2DD06538S7025641FKTHAEII",
      "rel": "self",
      "method": "GET"
    }
  ]
}
```

Reflection Code is https://github.com/chaitanyakuber/PayPal-PHP-SDK/blob/master/lib/PayPal/Common/PayPalModel.php#L184
When the above JSON is processed by this code we see "Method PayPal\Api\Sale::getTransactionFee() does not exist" in our logs.

Questions
- Are others seeing this issue ?
- Is this the right fix ?
