### PR TITLE
Added Default ApiContext to avoid passing it in all requests

### DIFF
--- a/lib/PayPal/Common/PayPalResourceModel.php
+++ b/lib/PayPal/Common/PayPalResourceModel.php
@@ -96,7 +96,14 @@ class PayPalResourceModel extends PayPalModel implements IResource
     protected static function executeCall($url, $method, $payLoad, $headers = array(), $apiContext = null, $restCall = null, $handlers = array('PayPal\Handler\RestHandler'))
     {
         //Initialize the context and rest call object if not provided explicitly
-        $apiContext = $apiContext ? $apiContext : new ApiContext(self::$credential);
+        if ($apiContext === null) {
+            // First try default ApiContext
+            $apiContext = ApiContext::getDefault();
+            if ($apiContext === null) {
+                $apiContext = new ApiContext(self::$credential);
+            }
+        }
+
         $restCall = $restCall ? $restCall : new PayPalRestCall($apiContext);
 
         //Make the execution call

--- a/lib/PayPal/Rest/ApiContext.php
+++ b/lib/PayPal/Rest/ApiContext.php
@@ -59,7 +59,7 @@ class ApiContext
      * @param string $payPalPartnerAttributionId
      * @return ApiContext
      */
-    public static function create($credential, $config=array(), $payPalPartnerAttributionId=null)
+    public static function create($credential = null, $config=array(), $payPalPartnerAttributionId=null)
     {
         // ### Api context
         // Use an ApiContext object to authenticate

--- a/lib/PayPal/Rest/ApiContext.php
+++ b/lib/PayPal/Rest/ApiContext.php
@@ -59,7 +59,7 @@ class ApiContext
      * @param string $payPalPartnerAttributionId
      * @return ApiContext
      */
-    public static function create($credential, $config = array(), $payPalPartnerAttributionId=null)
+    public static function create($credential, $config=array(), $payPalPartnerAttributionId=null)
     {
         // ### Api context
         // Use an ApiContext object to authenticate
@@ -83,7 +83,7 @@ class ApiContext
             $apiContext->addRequestHeader('PayPal-Partner-Attribution-Id', $payPalPartnerAttributionId);
         }
 
-        return self::$defaultApiContext;
+        return $apiContext;
     }
 
     /**

--- a/lib/PayPal/Rest/ApiContext.php
+++ b/lib/PayPal/Rest/ApiContext.php
@@ -2,6 +2,7 @@
 
 namespace PayPal\Rest;
 
+use PayPal\Auth\OAuthTokenCredential;
 use PayPal\Core\PayPalConfigManager;
 use PayPal\Core\PayPalCredentialManager;
 
@@ -14,6 +15,11 @@ use PayPal\Core\PayPalCredentialManager;
  */
 class ApiContext
 {
+    /**
+     * Default ApiContext when no ApiContext is provided as param.
+     * @var ApiContext
+     */
+    public static $defaultApiContext = null;
 
     /**
      * Unique request id to be used for this call
@@ -43,6 +49,60 @@ class ApiContext
     {
         $this->requestId = $requestId;
         $this->credential = $credential;
+    }
+
+    /**
+     * Create new default ApiContext.
+     *
+     * @param \PayPal\Auth\OAuthTokenCredential $credential
+     * @param array $config
+     * @param string $payPalPartnerAttributionId
+     * @return ApiContext
+     */
+    public static function create($credential, $config = array(), $payPalPartnerAttributionId=null)
+    {
+        // ### Api context
+        // Use an ApiContext object to authenticate
+        // API calls. The clientId and clientSecret for the
+        // OAuthTokenCredential class can be retrieved from
+        // developer.paypal.com
+
+        $apiContext = new ApiContext($credential);
+
+        // #### SDK configuration
+        // Register the sdk_config.ini file in current directory
+        // as the configuration source.
+        if(!defined("PP_CONFIG_PATH")) {
+            $apiContext->setConfig($config);
+        }
+
+        // Partner Attribution Id
+        // Use this header if you are a PayPal partner. Specify a unique BN Code to receive revenue attribution.
+        // To learn more or to request a BN Code, contact your Partner Manager or visit the PayPal Partner Portal
+        if ($payPalPartnerAttributionId !== null) {
+            $apiContext->addRequestHeader('PayPal-Partner-Attribution-Id', $payPalPartnerAttributionId);
+        }
+
+        return self::$defaultApiContext;
+    }
+
+    /**
+     * @param ApiContext $apiContext
+     * @return ApiContext
+     */
+    public static function setDefault($apiContext)
+    {
+        self::$defaultApiContext = $apiContext;
+    }
+
+    /**
+     * Returns default ApiContext.
+     *
+     * @return ApiContext
+     */
+    public static function getDefault()
+    {
+        return self::$defaultApiContext;
     }
 
     /**

--- a/sample/bootstrap.php
+++ b/sample/bootstrap.php
@@ -31,7 +31,7 @@ $clientSecret = 'EGnHDxD_qRPdaLdZz8iCr8N7_MzF-YHPTkjs6NKYQvQSBngp4PTTVWkPZRbL';
 
 /** @var \PayPal\Rest\ApiContext $apiContext */
 $apiContext = getApiContext($clientId, $clientSecret);
-//$apiContext = getApiContextUsingConfigIni($clientId, $clientSecret);
+//$apiContext = getApiContextUsingConfigIni();
 //$apiContext = getApiContextUsingConfigArray($clientId, $clientSecret);
 
 return $apiContext;
@@ -94,11 +94,9 @@ function getApiContext($clientId, $clientSecret)
 
 /**
  * Helper method for getting an APIContext for all calls
- * @param string $clientId Client ID
- * @param string $clientSecret Client Secret
  * @return PayPal\Rest\ApiContext
  */
-function getApiContextUsingConfigIni($clientId, $clientSecret)
+function getApiContextUsingConfigIni()
 {
     // #### SDK configuration
     // Register the sdk_config.ini file in current directory
@@ -107,19 +105,12 @@ function getApiContextUsingConfigIni($clientId, $clientSecret)
         define("PP_CONFIG_PATH", __DIR__);
     }
 
-    $credentials = new OAuthTokenCredential(
-        $clientId,
-        $clientSecret
-    );
-
-    $apiContext = ApiContext::create($credentials);
+    $apiContext = ApiContext::create();
 
     // Partner Attribution Id
     // Add this parameter if you are a PayPal partner. Specify a unique BN Code to receive revenue attribution.
     // To learn more or to request a BN Code, contact your Partner Manager or visit the PayPal Partner Portal
-    //$apiContext = ApiContext::create($credentials, null, '123123123');
-
-    ApiContext::setDefault($apiContext);
+    //$apiContext = ApiContext::create(null, null, '123123123');
 
     return $apiContext;
 }

--- a/sample/bootstrap.php
+++ b/sample/bootstrap.php
@@ -29,8 +29,10 @@ ini_set('display_errors', '1');
 $clientId = 'AYSq3RDGsmBLJE-otTkBtM-jBRd1TCQwFf9RGfwddNXWz0uFU9ztymylOhRS';
 $clientSecret = 'EGnHDxD_qRPdaLdZz8iCr8N7_MzF-YHPTkjs6NKYQvQSBngp4PTTVWkPZRbL';
 
-/** @var \Paypal\Rest\ApiContext $apiContext */
+/** @var \PayPal\Rest\ApiContext $apiContext */
 $apiContext = getApiContext($clientId, $clientSecret);
+//$apiContext = getApiContextUsingConfigIni($clientId, $clientSecret);
+//$apiContext = getApiContextUsingConfigArray($clientId, $clientSecret);
 
 return $apiContext;
 /**
@@ -41,7 +43,6 @@ return $apiContext;
  */
 function getApiContext($clientId, $clientSecret)
 {
-
     // #### SDK configuration
     // Register the sdk_config.ini file in current directory
     // as the configuration source.
@@ -51,19 +52,18 @@ function getApiContext($clientId, $clientSecret)
     }
     */
 
-
     // ### Api context
     // Use an ApiContext object to authenticate
     // API calls. The clientId and clientSecret for the
     // OAuthTokenCredential class can be retrieved from
     // developer.paypal.com
 
-    $apiContext = new ApiContext(
-        new OAuthTokenCredential(
-            $clientId,
-            $clientSecret
-        )
+    $credentials = new OAuthTokenCredential(
+        $clientId,
+        $clientSecret
     );
+
+    $apiContext = new ApiContext($credentials);
 
     // Comment this line out and uncomment the PP_CONFIG_PATH
     // 'define' block if you want to use static file
@@ -86,6 +86,76 @@ function getApiContext($clientId, $clientSecret)
     // Use this header if you are a PayPal partner. Specify a unique BN Code to receive revenue attribution.
     // To learn more or to request a BN Code, contact your Partner Manager or visit the PayPal Partner Portal
     // $apiContext->addRequestHeader('PayPal-Partner-Attribution-Id', '123123123');
+
+    ApiContext::setDefault($apiContext);
+
+    return $apiContext;
+}
+
+/**
+ * Helper method for getting an APIContext for all calls
+ * @param string $clientId Client ID
+ * @param string $clientSecret Client Secret
+ * @return PayPal\Rest\ApiContext
+ */
+function getApiContextUsingConfigIni($clientId, $clientSecret)
+{
+    // #### SDK configuration
+    // Register the sdk_config.ini file in current directory
+    // as the configuration source.
+    if(!defined("PP_CONFIG_PATH")) {
+        define("PP_CONFIG_PATH", __DIR__);
+    }
+
+    $credentials = new OAuthTokenCredential(
+        $clientId,
+        $clientSecret
+    );
+
+    $apiContext = ApiContext::create($credentials);
+
+    // Partner Attribution Id
+    // Add this parameter if you are a PayPal partner. Specify a unique BN Code to receive revenue attribution.
+    // To learn more or to request a BN Code, contact your Partner Manager or visit the PayPal Partner Portal
+    //$apiContext = ApiContext::create($credentials, null, '123123123');
+
+    ApiContext::setDefault($apiContext);
+
+    return $apiContext;
+}
+
+/**
+ * Helper method for getting an APIContext for all calls
+ * @param string $clientId Client ID
+ * @param string $clientSecret Client Secret
+ * @return PayPal\Rest\ApiContext
+ */
+function getApiContextUsingConfigArray($clientId, $clientSecret)
+{
+    $credentials = new OAuthTokenCredential(
+        $clientId,
+        $clientSecret
+    );
+
+    $config = array(
+        'mode' => 'sandbox',
+        'log.LogEnabled' => true,
+        'log.FileName' => '../PayPal.log',
+        'log.LogLevel' => 'DEBUG', // PLEASE USE `FINE` LEVEL FOR LOGGING IN LIVE ENVIRONMENTS
+        'validation.level' => 'log',
+        'cache.enabled' => true,
+        // 'http.CURLOPT_CONNECTTIMEOUT' => 30
+        // 'http.headers.PayPal-Partner-Attribution-Id' => '123123123'
+    );
+
+    $apiContext = ApiContext::create($credentials, $config);
+
+    // Partner Attribution Id
+    // Add this parameter if you are a PayPal partner. Specify a unique BN Code to receive revenue attribution.
+    // To learn more or to request a BN Code, contact your Partner Manager or visit the PayPal Partner Portal
+    //$apiContext = ApiContext::create($credentials, $config, '123123123');
+
+    ApiContext::setDefault($apiContext);
 
     return $apiContext;
 }

--- a/sample/invoice/ListInvoice.php
+++ b/sample/invoice/ListInvoice.php
@@ -14,7 +14,9 @@ try {
     // static `get_all` method on the Invoice class.
     // Refer the method doc for valid values for keys
     // (See bootstrap.php for more on `ApiContext`)
-    $invoices = Invoice::getAll(array('page' => 0, 'page_size' => 4, 'total_count_required' => "true"), $apiContext);
+    //$invoices = Invoice::getAll(array('page' => 0, 'page_size' => 4, 'total_count_required' => "true"), $apiContext);
+    // Test with default ApiContext
+    $invoices = Invoice::getAll(array('page' => 0, 'page_size' => 4, 'total_count_required' => "true"));
 } catch (Exception $ex) {
     // NOTE: PLEASE DO NOT USE RESULTPRINTER CLASS IN YOUR ORIGINAL CODE. FOR SAMPLE ONLY
  	ResultPrinter::printError("Lookup Invoice History", "Invoice", null, null, $ex);

--- a/tests/PayPal/Test/Core/PayPalLoggingManagerTest.php
+++ b/tests/PayPal/Test/Core/PayPalLoggingManagerTest.php
@@ -51,7 +51,15 @@ class PayPalLoggingManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInfo()
     {
-        $this->object->info('Test info Message');
+        $this->object->info('Test Info Message');
+    }
+
+    /**
+     * @test
+     */
+    public function testDebug()
+    {
+        $this->object->debug('Test Debug Message');
     }
 
     /**
@@ -59,8 +67,6 @@ class PayPalLoggingManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testFine()
     {
-        $this->object->fine('Test fine Message');
+        $this->object->fine('Test Fine Message');
     }
 }
-
-?>


### PR DESCRIPTION
Added static property/methods to ApiContext to store a default instance:

````php
ApiContext::setDefault($apiContext);
````

This way you can avoid passing ApiContext is you want to use always the same credentials:

````php
// sample ListInvoices
//$invoices = Invoice::getAll(array('page' => 0, 'page_size' => 4, 'total_count_required' => "true"), $apiContext);
// removed last parameter ApiContext
$invoices = Invoice::getAll(array('page' => 0, 'page_size' => 4, 'total_count_required' => "true"));
````