### PR TITLE
In OAuthTokenCredential public string variable AuthorizationCache that has the namespace path to the AuthorizationCache Class to access pull and push requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ composer.lock
 # Project
 var
 tools
+
+# Windows
+desktop.ini

--- a/lib/PayPal/Auth/OAuthTokenCredential.php
+++ b/lib/PayPal/Auth/OAuthTokenCredential.php
@@ -27,6 +27,11 @@ class OAuthTokenCredential extends PayPalResourceModel
     public static $AUTH_HANDLER = 'PayPal\Handler\OauthHandler';
 
     /**
+     * @var string Default AuthorizationCache Handler
+     */
+    public $AuthorizationCacheClass = 'PayPal\\Cache\\AuthorizationCache';
+
+    /**
      * Private Variable
      *
      * @var int $expiryBufferTime
@@ -130,7 +135,8 @@ class OAuthTokenCredential extends PayPalResourceModel
             return $this->accessToken;
         }
         // Check for persisted data first
-        $token = AuthorizationCache::pull($config, $this->clientId);
+        $AuthorizationCacheClass = $this->AuthorizationCacheClass;
+        $token = $AuthorizationCacheClass::pull($config, $this->clientId);
         if ($token) {
             // We found it
             // This code block is for backward compatibility only.
@@ -143,7 +149,7 @@ class OAuthTokenCredential extends PayPalResourceModel
 
             // Case where we have an old unencrypted cache file
             if (!array_key_exists('accessTokenEncrypted', $token)) {
-                AuthorizationCache::push($config, $this->clientId, $this->encrypt($this->accessToken), $this->tokenCreateTime, $this->tokenExpiresIn);
+                $AuthorizationCacheClass::push($config, $this->clientId, $this->encrypt($this->accessToken), $this->tokenCreateTime, $this->tokenExpiresIn);
             } else {
                 $this->accessToken = $this->decrypt($token['accessTokenEncrypted']);
             }
@@ -166,7 +172,7 @@ class OAuthTokenCredential extends PayPalResourceModel
         if ($this->accessToken == null) {
             // Get a new one by making calls to API
             $this->updateAccessToken($config);
-            AuthorizationCache::push($config, $this->clientId, $this->encrypt($this->accessToken), $this->tokenCreateTime, $this->tokenExpiresIn);
+            $AuthorizationCacheClass::push($config, $this->clientId, $this->encrypt($this->accessToken), $this->tokenCreateTime, $this->tokenExpiresIn);
         }
 
         return $this->accessToken;


### PR DESCRIPTION
### Main Goal

To allow implement any external cache solutions such as MongoDB, MySQL, Oracle, SQL Server, Redis, Memcache or any other easily, by extending or implementing the same methods as the original class.

### Issue related
#278 Ability to Cache Token to MongoDB or MySql

### Code example of an external cache

In this case we use MongoDB with a proprietary implementation, but ilustrates how easy is to implement an external cache:

```php
<?php

namespace MyNamespace\PayPal;

// Composer Loader
include_once 'composer/vendor/autoload.php';
use PayPal\Cache\AuthorizationCache as PayPal_AuthorizationCache;


/**
 * Special modification introduced by Matias Perrone for aluGuest.com
 * @author		Matias Perrone <matias@aluguest.com>
 * @uses		Mongo class
 * @copyright	2015 aluGuest.com (aluGuest LLC)
 */

class AuthorizationCache extends PayPal_AuthorizationCache
{
	public static $mongo = false;
	public static $colection = 'PayPalAuthorizationCache';

	public static function init()
	{
		if ( !self::$mongo )
    		self::$mongo = new MyNamespace\MyMongo();
	}

    /**
     * A pull method which would read the persisted data based on clientId.
     * If clientId is not provided, an array with all the tokens would be passed.
     *
     * @param array|null $config
     * @param string $clientId
     * @return mixed|null
     */
    public static function pull($config = null, $clientId = null)
    {
        // Return if not enabled
        if (!self::isEnabled($config)) { return null; }

    	self::init();

    	$tokens = null;
    	$find = array();
		$qty = 100;
		$page = 1;
		$total = null;
    	$fields = array('_id' => false);

		if ($clientId)
		{
			$find['clientId'] = $clientId;
			$tokens = self::$mongo->getItem(self::$colection, $find, $fields);
			if (!$tokens)
				$tokens = null;
		}
		else
		{
			$tokens = self::$mongo->getAll(self::$colection, $qty, $page, $total, $find, $fields);
		}
        return $tokens;
    }

    /**
     * Persists the data into the "mongo" cache
     *
     * @param array|null $config
     * @param      $clientId
     * @param      $accessToken
     * @param      $tokenCreateTime
     * @param      $tokenExpiresIn
     * @throws \Exception
     */
    public static function push($config = null, $clientId, $accessToken, $tokenCreateTime, $tokenExpiresIn)
    {
        // Return if not enabled
        if (!self::isEnabled($config)) { return null; }

    	self::init();

        $data = array(
            'clientId' => $clientId,
            'accessTokenEncrypted' => $accessToken,
            'tokenCreateTime' => $tokenCreateTime,
            'tokenExpiresIn' => $tokenExpiresIn
        );
    	$expireAfterSeconds = $tokenExpiresIn;
    	$CreateIndexField = 'clientId';
    	$CreateIndexUnique = true;
        $ok = self::$mongo->saveData(self::$colection, $CreateIndexField, $data, $expireAfterSeconds, $CreateIndexUnique);
        if (!$ok)
        {
            throw new \Exception("Failed to write cache");
        };
    }
}
```


