### PR TITLE
Add Travis-CI PHP 7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
 - 5.4
 - 5.5
 - 5.6
+- 7.0
 - hhvm
 matrix:
   allow_failures:

--- a/lib/PayPal/Validation/JsonValidator.php
+++ b/lib/PayPal/Validation/JsonValidator.php
@@ -21,6 +21,9 @@ class JsonValidator
     {
         @json_decode($string);
         if (json_last_error() != JSON_ERROR_NONE) {
+            if ($string === '' || $string === null) {
+                return true;
+            }
             if ($silent == false) {
                 //Throw an Exception for string or array
                 throw new \InvalidArgumentException("Invalid JSON String");


### PR DESCRIPTION
* Made behavior compatible fix for PHP 7 (so JsonValidator behaves the same for PHP 5.x and PHP 7.x) for empty string/null values. PHP 7.x will report an error on json_decode if the string is empty or null.
* Add Travis-CI PHP 7.0 support.