### PR TITLE
Fixed unclaimed typo.

### DIFF
--- a/sample/index.php
+++ b/sample/index.php
@@ -419,7 +419,7 @@ if (PHP_SAPI == 'cli') {
                     </li>
                     <li class="list-group-item">
                         <div class="row">
-                            <div class="col-md-8"><h5>Cancel Uncliamed Payout Item</h5></div>
+                            <div class="col-md-8"><h5>Cancel Unclaimed Payout Item</h5></div>
                             <div class="col-md-4">
                                 <a href="payouts/CancelPayoutItem.php" class="btn btn-primary pull-left execute"> Try It <i
                                         class="fa fa-play-circle-o"></i></a>


### PR DESCRIPTION
Fixing a typo "Uncliamed" -> "Unclaimed" in sample docs.