### PR TITLE
Allow updates of psr/log package <2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "psr/log": "1.0.0"
+        "psr/log": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
psr/log is now at 1.0.1 but held back to 1.0.0.

as per https://getcomposer.org/doc/articles/versions.md#caret

Many thanks.