### PR TITLE
bugfix: UTF8 encoding in result response from sandbox, corrupts json response

### DIFF
--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -149,9 +149,16 @@ class PayPalHttpConnection
         // Get Request and Response Headers
         $requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
         //Using alternative solution to CURLINFO_HEADER_SIZE as it throws invalid number when called using PROXY.
-        $responseHeaderSize = mb_strlen($result,'8bit') - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
-        $responseHeaders = mb_substr($result, 0, $responseHeaderSize, '8bit');
-        $result = mb_substr($result, $responseHeaderSize, null, '8bit');
+        if (function_exists('mb_strlen')) {
+            $responseHeaderSize = mb_strlen($result, '8bit') - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
+            $responseHeaders = mb_substr($result, 0, $responseHeaderSize, '8bit');
+            $result = mb_substr($result, $responseHeaderSize, null, '8bit');
+        } else {
+            $responseHeaderSize = strlen($result) - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
+            $responseHeaders = substr($result, 0, $responseHeaderSize);
+            $result = substr($result, $responseHeaderSize);
+
+        }
 
         $this->logger->debug("Request Headers \t: " . str_replace("\r\n", ", ", $requestHeaders));
         $this->logger->debug(($data && $data != '' ? "Request Data\t\t: " . $data : "No Request Payload") . "\n" . str_repeat('-', 128) . "\n");

--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -146,12 +146,12 @@ class PayPalHttpConnection
             throw $ex;
         }
 
-        // Get Request and Response Headers
-        $requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
-        //Using alternative solution to CURLINFO_HEADER_SIZE as it throws invalid number when called using PROXY.
-        $responseHeaderSize = strlen($result) - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
-        $responseHeaders = substr($result, 0, $responseHeaderSize);
-        $result = substr($result, $responseHeaderSize);
+		// Get Request and Response Headers
+		$requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
+		//Using alternative solution to CURLINFO_HEADER_SIZE as it throws invalid number when called using PROXY.
+		$responseHeaderSize = mb_strlen($result,'8bit') - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
+		$responseHeaders = mb_substr($result, 0, $responseHeaderSize, '8bit');
+		$result = mb_substr($result, $responseHeaderSize, null, '8bit');
 
         $this->logger->debug("Request Headers \t: " . str_replace("\r\n", ", ", $requestHeaders));
         $this->logger->debug(($data && $data != '' ? "Request Data\t\t: " . $data : "No Request Payload") . "\n" . str_repeat('-', 128) . "\n");

--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -146,12 +146,12 @@ class PayPalHttpConnection
             throw $ex;
         }
 
-		// Get Request and Response Headers
-		$requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
-		//Using alternative solution to CURLINFO_HEADER_SIZE as it throws invalid number when called using PROXY.
-		$responseHeaderSize = mb_strlen($result,'8bit') - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
-		$responseHeaders = mb_substr($result, 0, $responseHeaderSize, '8bit');
-		$result = mb_substr($result, $responseHeaderSize, null, '8bit');
+        // Get Request and Response Headers
+        $requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
+        //Using alternative solution to CURLINFO_HEADER_SIZE as it throws invalid number when called using PROXY.
+        $responseHeaderSize = mb_strlen($result,'8bit') - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
+        $responseHeaders = mb_substr($result, 0, $responseHeaderSize, '8bit');
+        $result = mb_substr($result, $responseHeaderSize, null, '8bit');
 
         $this->logger->debug("Request Headers \t: " . str_replace("\r\n", ", ", $requestHeaders));
         $this->logger->debug(($data && $data != '' ? "Request Data\t\t: " . $data : "No Request Payload") . "\n" . str_repeat('-', 128) . "\n");

--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -157,7 +157,6 @@ class PayPalHttpConnection
             $responseHeaderSize = strlen($result) - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
             $responseHeaders = substr($result, 0, $responseHeaderSize);
             $result = substr($result, $responseHeaderSize);
-
         }
 
         $this->logger->debug("Request Headers \t: " . str_replace("\r\n", ", ", $requestHeaders));


### PR DESCRIPTION
@jaypatel512 
- PHP 5.6:
- PayPal-PHP-SDK 1.7.4:
- Debug ID(s):

file /lib/PayPal/Core\PayPalHttpConnection.php line 150 reads
        // Get Request and Response Headers
        $requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
        //Using alternative solution to CURLINFO_HEADER_SIZE as it throws invalid number when called using PROXY.
        $responseHeaderSize = strlen($result) - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
        $responseHeaders = substr($result, 0, $responseHeaderSize);
        $result = substr($result, $responseHeaderSize);

The response getting from curl_exec is a string, which is binary. In my case strlen is treating this binary string as UTF8 and is returning a different strlen than the string is when written to disk, using characters like 'äöü ... '. strlen seems to be replaced with mb_strlen, which then uses the default encoding ( UTF8 ).

A better approach is to use mb_strlen in combination with 8bit encoding.
Any idea, if utf_decode has to be used, too ?

see: php.ini using mbstring.func_overload