### PR TITLE
Error: Could not generate new Access token. Invalid response from server 

### DIFF
--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -152,7 +152,7 @@ class PayPalHttpConnection
         if (function_exists('mb_strlen')) {
             $responseHeaderSize = mb_strlen($result, '8bit') - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
             $responseHeaders = mb_substr($result, 0, $responseHeaderSize, '8bit');
-            $result = mb_substr($result, $responseHeaderSize, null, '8bit');
+            $result = mb_substr($result, $responseHeaderSize, mb_strlen($result), '8bit');
         } else {
             $responseHeaderSize = strlen($result) - curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD);
             $responseHeaders = substr($result, 0, $responseHeaderSize);


### PR DESCRIPTION
Passing null as length will not make mb_substr use it's default, instead it will interpret it as 0.
$result = mb_substr($result, $responseHeaderSize, null, '8bit');
Instead use:
$result = mb_substr($result, $responseHeaderSize, mb_strlen($result), '8bit');