### PR TITLE
Update PayPalHttpConfig.php

### DIFF
--- a/lib/PayPal/Core/PayPalHttpConfig.php
+++ b/lib/PayPal/Core/PayPalHttpConfig.php
@@ -64,7 +64,7 @@ class PayPalHttpConfig
         // Update the Cipher List based on OpenSSL or NSS settings
         $curl = curl_version();
         $sslVersion = isset($curl['ssl_version']) ? $curl['ssl_version'] : '';
-        if (substr_compare($sslVersion, "NSS/", 0, strlen("NSS/")) === 0) {
+        if($sslVersion && substr_compare($sslVersion, "NSS/", 0, strlen("NSS/")) === 0) {
             //Remove the Cipher List for NSS
             $this->removeCurlOption(CURLOPT_SSL_CIPHER_LIST);
         }


### PR DESCRIPTION
To prefent : 
            ErrorException in PayPalHttpConfig.php line 67: substr_compare(): 
            The start position cannot exceed initial string length
Add the extra check on line 67 to check if SSLversion is something. Since Google App Engine does not support CURL this check prevents the application of crashing