### PR TITLE
Allow single object for Payment->setTransactions()

### DIFF
--- a/lib/PayPal/Api/Payment.php
+++ b/lib/PayPal/Api/Payment.php
@@ -176,6 +176,9 @@ class Payment extends PayPalResourceModel
      */
     public function setTransactions($transactions)
     {
+        if (!is_array($transactions)) {
+            $transactions = array($transactions);
+        }
         $this->transactions = $transactions;
         return $this;
     }

--- a/tests/PayPal/Test/Api/PaymentTest.php
+++ b/tests/PayPal/Test/Api/PaymentTest.php
@@ -2,7 +2,9 @@
 
 namespace PayPal\Test\Api;
 
+use PayPal\Api\Amount;
 use PayPal\Api\Payment;
+use PayPal\Api\Transaction;
 
 /**
  * Class Payment
@@ -197,5 +199,20 @@ class PaymentTest extends \PHPUnit_Framework_TestCase
             array($obj, $mockApiContext),
             array($obj, null)
         );
+    }
+
+    /**
+     * Tests setting a payment transactions to a single object will automatically
+     * convert to an array.
+     */
+    public function testTransactionSingleObjectConvertedToArray()
+    {
+        $payment = new Payment();
+        $singleTransaction = new Transaction();
+        $amount = new Amount();
+        $amount->setCurrency("USD")->setTotal("1.00");
+        $singleTransaction->setAmount($amount);
+        $payment->setTransactions($singleTransaction);
+        $this->assertEquals(array($singleTransaction), $payment->getTransactions());
     }
 }


### PR DESCRIPTION
- Add convenience to allow a single transaction object to be set for
  the payment. It automatically promotes it to an array.