### PR TITLE
PayPal Request ID changes

### DIFF
--- a/lib/PayPal/Handler/RestHandler.php
+++ b/lib/PayPal/Handler/RestHandler.php
@@ -82,7 +82,7 @@ class RestHandler implements IPayPalHandler
             $httpConfig->addHeader('Authorization', "Bearer " . $credential->getAccessToken($config), false);
         }
 
-        if ($httpConfig->getMethod() == 'POST' || $httpConfig->getMethod() == 'PUT') {
+        if (($httpConfig->getMethod() == 'POST' || $httpConfig->getMethod() == 'PUT') && !is_null($this->apiContext->getRequestId())) {
             $httpConfig->addHeader('PayPal-Request-Id', $this->apiContext->getRequestId());
         }
         // Add any additional Headers that they may have provided

--- a/lib/PayPal/Rest/ApiContext.php
+++ b/lib/PayPal/Rest/ApiContext.php
@@ -102,6 +102,7 @@ class ApiContext
      * Resets the requestId that can be used to set the PayPal-request-id
      * header used for idempotency. In cases where you need to make multiple create calls
      * using the same ApiContext object, you need to reset request Id.
+     * @deprecated Call setRequestId with a unique value.
      *
      * @return string
      */
@@ -146,6 +147,7 @@ class ApiContext
      * Generates a unique per request id that
      * can be used to set the PayPal-Request-Id header
      * that is used for idempotency
+     * @deprecated
      *
      * @return string
      */

--- a/lib/PayPal/Rest/ApiContext.php
+++ b/lib/PayPal/Rest/ApiContext.php
@@ -85,11 +85,17 @@ class ApiContext
      */
     public function getRequestId()
     {
-        if ($this->requestId == null) {
-            $this->requestId = $this->generateRequestId();
-        }
-
         return $this->requestId;
+    }
+
+    /**
+     * Sets the request ID
+     *
+     * @param string $requestId the PayPal-Request-Id value to use
+     */
+    public function setRequestId($requestId)
+    {
+        $this->requestId = $requestId;
     }
 
     /**

--- a/tests/PayPal/Test/Rest/ApiContextTest.php
+++ b/tests/PayPal/Test/Rest/ApiContextTest.php
@@ -22,13 +22,27 @@ class ApiContextTest extends PHPUnit_Framework_TestCase
     public function testGetRequestId()
     {
         $requestId = $this->apiContext->getRequestId();
-        $this->assertNotNull($requestId);
-        $this->assertEquals($requestId, $this->apiContext->getRequestId());
+        $this->assertNull($requestId);
+    }
+
+    public function testSetRequestId()
+    {
+        $this->assertNull($this->apiContext->getRequestId());
+
+        $expectedRequestId = 'random-value';
+        $this->apiContext->setRequestId($expectedRequestId);
+        $requestId = $this->apiContext->getRequestId();
+        $this->assertEquals($expectedRequestId, $requestId);
     }
 
     public function testResetRequestId()
     {
-        $requestId = $this->apiContext->getRequestId();
+        $this->assertNull($this->apiContext->getRequestId());
+
+        $requestId = $this->apiContext->resetRequestId();
+        $this->assertNotNull($requestId);
+
+        // Tests that another resetRequestId call will generate a new ID
         $newRequestId = $this->apiContext->resetRequestId();
         $this->assertNotNull($newRequestId);
         $this->assertNotEquals($newRequestId, $requestId);


### PR DESCRIPTION
In order to allow better re-usage of ApiContext, do not automatically set the PayPal-Request-ID and allow manual setting of the PayPal-Request-ID value.

Also remove the automatic retries, so that the developer has full control on retry conditions.