### PR TITLE
E_WARNING strstr(): Empty needle

### DIFF
--- a/lib/PayPal/Core/PayPalConfigManager.php
+++ b/lib/PayPal/Core/PayPalConfigManager.php
@@ -100,11 +100,11 @@ class PayPalConfigManager
         } else {
             $arr = array();
             if ($searchKey !== '') {
-            foreach ($this->configs as $k => $v) {
-                if (strstr($k, $searchKey)) {
-                    $arr[$k] = $v;
+                foreach ($this->configs as $k => $v) {
+                    if (strstr($k, $searchKey)) {
+                        $arr[$k] = $v;
+                    }
                 }
-            }
             }
 
             return $arr;

--- a/lib/PayPal/Core/PayPalConfigManager.php
+++ b/lib/PayPal/Core/PayPalConfigManager.php
@@ -99,10 +99,12 @@ class PayPalConfigManager
             return $this->configs[$searchKey];
         } else {
             $arr = array();
+            if ($searchKey !== '') {
             foreach ($this->configs as $k => $v) {
                 if (strstr($k, $searchKey)) {
                     $arr[$k] = $v;
                 }
+            }
             }
 
             return $arr;


### PR DESCRIPTION
PHP 7.1, CentOS; when attempting to get the link for the oauth button to obtain login scopes, our dev server triggered an E_WARNING:
```sh
Whoops\Exception\ErrorException thrown with message "strstr(): Empty needle"

Stacktrace:
#12 Whoops\Exception\ErrorException in /httpdocs/vendor/paypal/rest-api-sdk-php/lib/PayPal/Core/PayPalConfigManager.php:103
#11 strstr in /httpdocs/vendor/paypal/rest-api-sdk-php/lib/PayPal/Core/PayPalConfigManager.php:103
#10 PayPal\Core\PayPalConfigManager:get in /httpdocs/vendor/paypal/rest-api-sdk-php/lib/PayPal/Rest/ApiContext.php:143
#9 PayPal\Rest\ApiContext:get in /httpdocs/vendor/paypal/rest-api-sdk-php/lib/PayPal/Api/OpenIdSession.php:31
```

This error was negated by checking for an empty string in 482c153, with 8af4d7d being the corresponding indentation change.