### PR TITLE
Add TLSv1.2 to cipher list

### DIFF
--- a/lib/PayPal/Core/PayPalHttpConfig.php
+++ b/lib/PayPal/Core/PayPalHttpConfig.php
@@ -27,7 +27,7 @@ class PayPalHttpConfig
         CURLOPT_HTTPHEADER => array(),
         CURLOPT_SSL_VERIFYHOST => 2,
         CURLOPT_SSL_VERIFYPEER => 1,
-        CURLOPT_SSL_CIPHER_LIST => 'TLSv1'
+        CURLOPT_SSL_CIPHER_LIST => 'TLSv1:TLSv1.2'
         //Allowing TLSv1 cipher list.
         //Adding it like this for backward compatibility with older versions of curl
     );


### PR DESCRIPTION
With openssl 1.1 using only `TLSv1` in the cipher list causes the following exception which is fixed by adding TLSv1.2 to the list:

    Exception PayPal\Exception\PayPalConnectionException: "PayPal\Exception\PayPalConnectionException: error:141640B5:SSL routines:tls_construct_client_hello:no ciphers available"