### PR TITLE
Make Proxy Configuration Work

### DIFF
--- a/lib/PayPal/Auth/OAuthTokenCredential.php
+++ b/lib/PayPal/Auth/OAuthTokenCredential.php
@@ -226,6 +226,11 @@ class OAuthTokenCredential extends PayPalResourceModel
     {
         $httpConfig = new PayPalHttpConfig(null, 'POST', $config);
 
+        // if proxy set via config, add it
+        if (!empty($config['http.Proxy'])) {
+            $httpConfig->setHttpProxy($config['http.Proxy']);
+        }
+
         $handlers = array(self::$AUTH_HANDLER);
 
         /** @var IPayPalHandler $handler */

--- a/lib/PayPal/Transport/PayPalRestCall.php
+++ b/lib/PayPal/Transport/PayPalRestCall.php
@@ -61,6 +61,11 @@ class PayPalRestCall
             )
         );
 
+        // if proxy set via config, add it
+        if (!empty($config['http.Proxy'])) {
+            $httpConfig->setHttpProxy($config['http.Proxy']);
+        }
+
         /** @var \Paypal\Handler\IPayPalHandler $handler */
         foreach ($handlers as $handler) {
             if (!is_object($handler)) {


### PR DESCRIPTION
Proxy setting were not being respected, so once  is
returned, setHttpProxy() is called to add the proxy option if
need prior to getting and OAuth token or executing a call to
PayPal