### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/log": "^1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-0": {

--- a/tests/PayPal/Test/Api/AddressTest.php
+++ b/tests/PayPal/Test/Api/AddressTest.php
@@ -1,15 +1,15 @@
 <?php
-
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Address;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Address
  *
  * @package PayPal\Test\Api
  */
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
     /**
      * Gets Json String of Object Address
@@ -28,7 +28,6 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     {
         return new Address(self::getJson());
     }
-
 
     /**
      * Tests for Serialization and Deserialization Issues

--- a/tests/PayPal/Test/Api/AgreementStateDescriptorTest.php
+++ b/tests/PayPal/Test/Api/AgreementStateDescriptorTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\AgreementStateDescriptor;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class AgreementStateDescriptor
  *
  * @package PayPal\Test\Api
  */
-class AgreementStateDescriptorTest extends \PHPUnit_Framework_TestCase
+class AgreementStateDescriptorTest extends TestCase
 {
     /**
      * Gets Json String of Object AgreementStateDescriptor

--- a/tests/PayPal/Test/Api/AgreementTest.php
+++ b/tests/PayPal/Test/Api/AgreementTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Agreement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Agreement
  *
  * @package PayPal\Test\Api
  */
-class AgreementTest extends \PHPUnit_Framework_TestCase
+class AgreementTest extends TestCase
 {
     /**
      * Gets Json String of Object Agreement

--- a/tests/PayPal/Test/Api/AgreementTransactionTest.php
+++ b/tests/PayPal/Test/Api/AgreementTransactionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\AgreementTransaction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class AgreementTransaction
  *
  * @package PayPal\Test\Api
  */
-class AgreementTransactionTest extends \PHPUnit_Framework_TestCase
+class AgreementTransactionTest extends TestCase
 {
     /**
      * Gets Json String of Object AgreementTransaction

--- a/tests/PayPal/Test/Api/AgreementTransactionsTest.php
+++ b/tests/PayPal/Test/Api/AgreementTransactionsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\AgreementTransactions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class AgreementTransactions
  *
  * @package PayPal\Test\Api
  */
-class AgreementTransactionsTest extends \PHPUnit_Framework_TestCase
+class AgreementTransactionsTest extends TestCase
 {
     /**
      * Gets Json String of Object AgreementTransactions

--- a/tests/PayPal/Test/Api/AlternatePaymentTest.php
+++ b/tests/PayPal/Test/Api/AlternatePaymentTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\AlternatePayment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class AlternatePayment
  *
  * @package PayPal\Test\Api
  */
-class AlternatePaymentTest extends \PHPUnit_Framework_TestCase
+class AlternatePaymentTest extends TestCase
 {
     /**
      * Gets Json String of Object AlternatePayment

--- a/tests/PayPal/Test/Api/AmountTest.php
+++ b/tests/PayPal/Test/Api/AmountTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Amount;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Amount
  *
  * @package PayPal\Test\Api
  */
-class AmountTest extends \PHPUnit_Framework_TestCase
+class AmountTest extends TestCase
 {
     /**
      * Gets Json String of Object Amount

--- a/tests/PayPal/Test/Api/AuthorizationTest.php
+++ b/tests/PayPal/Test/Api/AuthorizationTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Api\Authorization;
 use PayPal\Transport\PPRestCall;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Authorization
  *
  * @package PayPal\Test\Api
  */
-class AuthorizationTest extends \PHPUnit_Framework_TestCase
+class AuthorizationTest extends TestCase
 {
     /**
      * Gets Json String of Object Authorization

--- a/tests/PayPal/Test/Api/BankAccountTest.php
+++ b/tests/PayPal/Test/Api/BankAccountTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\BankAccount;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class BankAccount
  *
  * @package PayPal\Test\Api
  */
-class BankAccountTest extends \PHPUnit_Framework_TestCase
+class BankAccountTest extends TestCase
 {
     /**
      * Gets Json String of Object BankAccount

--- a/tests/PayPal/Test/Api/BankAccountsListTest.php
+++ b/tests/PayPal/Test/Api/BankAccountsListTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\BankAccountsList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class BankAccountsList
  *
  * @package PayPal\Test\Api
  */
-class BankAccountsListTest extends \PHPUnit_Framework_TestCase
+class BankAccountsListTest extends TestCase
 {
     /**
      * Gets Json String of Object BankAccountsList

--- a/tests/PayPal/Test/Api/BankTokenTest.php
+++ b/tests/PayPal/Test/Api/BankTokenTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\BankToken;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class BankToken
  *
  * @package PayPal\Test\Api
  */
-class BankTokenTest extends \PHPUnit_Framework_TestCase
+class BankTokenTest extends TestCase
 {
     /**
      * Gets Json String of Object BankToken

--- a/tests/PayPal/Test/Api/BillingInfoTest.php
+++ b/tests/PayPal/Test/Api/BillingInfoTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\BillingInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class BillingInfo
  *
  * @package PayPal\Test\Api
  */
-class BillingInfoTest extends \PHPUnit_Framework_TestCase
+class BillingInfoTest extends TestCase
 {
     /**
      * Gets Json String of Object BillingInfo

--- a/tests/PayPal/Test/Api/BillingTest.php
+++ b/tests/PayPal/Test/Api/BillingTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Billing;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Billing
  *
  * @package PayPal\Test\Api
  */
-class BillingTest extends \PHPUnit_Framework_TestCase
+class BillingTest extends TestCase
 {
     /**
      * Gets Json String of Object Billing

--- a/tests/PayPal/Test/Api/CancelNotificationTest.php
+++ b/tests/PayPal/Test/Api/CancelNotificationTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CancelNotification;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CancelNotification
  *
  * @package PayPal\Test\Api
  */
-class CancelNotificationTest extends \PHPUnit_Framework_TestCase
+class CancelNotificationTest extends TestCase
 {
     /**
      * Gets Json String of Object CancelNotification

--- a/tests/PayPal/Test/Api/CaptureTest.php
+++ b/tests/PayPal/Test/Api/CaptureTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Api\Capture;
 use PayPal\Transport\PPRestCall;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Capture
  *
  * @package PayPal\Test\Api
  */
-class CaptureTest extends \PHPUnit_Framework_TestCase
+class CaptureTest extends TestCase
 {
     /**
      * Gets Json String of Object Capture

--- a/tests/PayPal/Test/Api/CarrierAccountTest.php
+++ b/tests/PayPal/Test/Api/CarrierAccountTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CarrierAccount;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CarrierAccount
  *
  * @package PayPal\Test\Api
  */
-class CarrierAccountTest extends \PHPUnit_Framework_TestCase
+class CarrierAccountTest extends TestCase
 {
     /**
      * Gets Json String of Object CarrierAccount

--- a/tests/PayPal/Test/Api/CarrierAccountTokenTest.php
+++ b/tests/PayPal/Test/Api/CarrierAccountTokenTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CarrierAccountToken;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CarrierAccountToken
  *
  * @package PayPal\Test\Api
  */
-class CarrierAccountTokenTest extends \PHPUnit_Framework_TestCase
+class CarrierAccountTokenTest extends TestCase
 {
     /**
      * Gets Json String of Object CarrierAccountToken

--- a/tests/PayPal/Test/Api/CartBaseTest.php
+++ b/tests/PayPal/Test/Api/CartBaseTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\CartBase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CartBase
  *
  * @package PayPal\Test\Api
  */
-class CartBaseTest extends \PHPUnit_Framework_TestCase
+class CartBaseTest extends TestCase
 {
     /**
      * Gets Json String of Object CartBase

--- a/tests/PayPal/Test/Api/ChargeModelTest.php
+++ b/tests/PayPal/Test/Api/ChargeModelTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ChargeModel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ChargeModel
  *
  * @package PayPal\Test\Api
  */
-class ChargeModelTest extends \PHPUnit_Framework_TestCase
+class ChargeModelTest extends TestCase
 {
     /**
      * Gets Json String of Object ChargeModels

--- a/tests/PayPal/Test/Api/CostTest.php
+++ b/tests/PayPal/Test/Api/CostTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Cost;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Cost
  *
  * @package PayPal\Test\Api
  */
-class CostTest extends \PHPUnit_Framework_TestCase
+class CostTest extends TestCase
 {
     /**
      * Gets Json String of Object Cost

--- a/tests/PayPal/Test/Api/CountryCodeTest.php
+++ b/tests/PayPal/Test/Api/CountryCodeTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CountryCode;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CountryCode
  *
  * @package PayPal\Test\Api
  */
-class CountryCodeTest extends \PHPUnit_Framework_TestCase
+class CountryCodeTest extends TestCase
 {
     /**
      * Gets Json String of Object CountryCode

--- a/tests/PayPal/Test/Api/CreateProfileResponseTest.php
+++ b/tests/PayPal/Test/Api/CreateProfileResponseTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CreateProfileResponse;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CreateProfileResponse
  *
  * @package PayPal\Test\Api
  */
-class CreateProfileResponseTest extends \PHPUnit_Framework_TestCase
+class CreateProfileResponseTest extends TestCase
 {
     /**
      * Gets Json String of Object CreateProfileResponse

--- a/tests/PayPal/Test/Api/CreditCardHistoryTest.php
+++ b/tests/PayPal/Test/Api/CreditCardHistoryTest.php
@@ -3,8 +3,9 @@ namespace PayPal\Test\Api;
 
 use PayPal\Api\CreditCard;
 use PayPal\Api\CreditCardHistory;
+use PHPUnit\Framework\TestCase;
 
-class CreditCardHistoryTest extends \PHPUnit_Framework_TestCase
+class CreditCardHistoryTest extends TestCase
 {
 
     private $cards;

--- a/tests/PayPal/Test/Api/CreditCardListTest.php
+++ b/tests/PayPal/Test/Api/CreditCardListTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CreditCardList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CreditCardList
  *
  * @package PayPal\Test\Api
  */
-class CreditCardListTest extends \PHPUnit_Framework_TestCase
+class CreditCardListTest extends TestCase
 {
     /**
      * Gets Json String of Object CreditCardList

--- a/tests/PayPal/Test/Api/CreditCardTest.php
+++ b/tests/PayPal/Test/Api/CreditCardTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CreditCard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CreditCard
  *
  * @package PayPal\Test\Api
  */
-class CreditCardTest extends \PHPUnit_Framework_TestCase
+class CreditCardTest extends TestCase
 {
     /**
      * Gets Json String of Object CreditCard

--- a/tests/PayPal/Test/Api/CreditCardTokenTest.php
+++ b/tests/PayPal/Test/Api/CreditCardTokenTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CreditCardToken;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CreditCardToken
  *
  * @package PayPal\Test\Api
  */
-class CreditCardTokenTest extends \PHPUnit_Framework_TestCase
+class CreditCardTokenTest extends TestCase
 {
     /**
      * Gets Json String of Object CreditCardToken

--- a/tests/PayPal/Test/Api/CreditFinancingOfferedTest.php
+++ b/tests/PayPal/Test/Api/CreditFinancingOfferedTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CreditFinancingOffered;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CreditFinancingOffered
  *
  * @package PayPal\Test\Api
  */
-class CreditFinancingOfferedTest extends \PHPUnit_Framework_TestCase
+class CreditFinancingOfferedTest extends TestCase
 {
     /**
      * Gets Json String of Object CreditFinancingOffered

--- a/tests/PayPal/Test/Api/CreditTest.php
+++ b/tests/PayPal/Test/Api/CreditTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Credit;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Credit
  *
  * @package PayPal\Test\Api
  */
-class CreditTest extends \PHPUnit_Framework_TestCase
+class CreditTest extends TestCase
 {
     /**
      * Gets Json String of Object Credit

--- a/tests/PayPal/Test/Api/CurrencyConversionTest.php
+++ b/tests/PayPal/Test/Api/CurrencyConversionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CurrencyConversion;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CurrencyConversion
  *
  * @package PayPal\Test\Api
  */
-class CurrencyConversionTest extends \PHPUnit_Framework_TestCase
+class CurrencyConversionTest extends TestCase
 {
     /**
      * Gets Json String of Object CurrencyConversion

--- a/tests/PayPal/Test/Api/CurrencyTest.php
+++ b/tests/PayPal/Test/Api/CurrencyTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Currency;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Currency
  *
  * @package PayPal\Test\Api
  */
-class CurrencyTest extends \PHPUnit_Framework_TestCase
+class CurrencyTest extends TestCase
 {
     /**
      * Gets Json String of Object Currency

--- a/tests/PayPal/Test/Api/CustomAmountTest.php
+++ b/tests/PayPal/Test/Api/CustomAmountTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\CustomAmount;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CustomAmount
  *
  * @package PayPal\Test\Api
  */
-class CustomAmountTest extends \PHPUnit_Framework_TestCase
+class CustomAmountTest extends TestCase
 {
     /**
      * Gets Json String of Object CustomAmount

--- a/tests/PayPal/Test/Api/DetailedRefundTest.php
+++ b/tests/PayPal/Test/Api/DetailedRefundTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\DetailedRefund;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DetailedRefund
  *
  * @package PayPal\Test\Api
  */
-class DetailedRefundTest extends \PHPUnit_Framework_TestCase
+class DetailedRefundTest extends TestCase
 {
     /**
      * Gets Json String of Object DetailedRefund

--- a/tests/PayPal/Test/Api/DetailsTest.php
+++ b/tests/PayPal/Test/Api/DetailsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Details;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Details
  *
  * @package PayPal\Test\Api
  */
-class DetailsTest extends \PHPUnit_Framework_TestCase
+class DetailsTest extends TestCase
 {
     /**
      * Gets Json String of Object Details

--- a/tests/PayPal/Test/Api/ErrorDetailsTest.php
+++ b/tests/PayPal/Test/Api/ErrorDetailsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ErrorDetails;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ErrorDetails
  *
  * @package PayPal\Test\Api
  */
-class ErrorDetailsTest extends \PHPUnit_Framework_TestCase
+class ErrorDetailsTest extends TestCase
 {
     /**
      * Gets Json String of Object ErrorDetails

--- a/tests/PayPal/Test/Api/ErrorTest.php
+++ b/tests/PayPal/Test/Api/ErrorTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Error;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Error
  *
  * @package PayPal\Test\Api
  */
-class ErrorTest extends \PHPUnit_Framework_TestCase
+class ErrorTest extends TestCase
 {
     /**
      * Gets Json String of Object Error

--- a/tests/PayPal/Test/Api/ExtendedBankAccountTest.php
+++ b/tests/PayPal/Test/Api/ExtendedBankAccountTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ExtendedBankAccount;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ExtendedBankAccount
  *
  * @package PayPal\Test\Api
  */
-class ExtendedBankAccountTest extends \PHPUnit_Framework_TestCase
+class ExtendedBankAccountTest extends TestCase
 {
     /**
      * Gets Json String of Object ExtendedBankAccount

--- a/tests/PayPal/Test/Api/ExternalFundingTest.php
+++ b/tests/PayPal/Test/Api/ExternalFundingTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ExternalFunding;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ExternalFunding
  *
  * @package PayPal\Test\Api
  */
-class ExternalFundingTest extends \PHPUnit_Framework_TestCase
+class ExternalFundingTest extends TestCase
 {
     /**
      * Gets Json String of Object ExternalFunding

--- a/tests/PayPal/Test/Api/FileAttachmentTest.php
+++ b/tests/PayPal/Test/Api/FileAttachmentTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\FileAttachment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FileAttachment
  *
  * @package PayPal\Test\Api
  */
-class FileAttachmentTest extends \PHPUnit_Framework_TestCase
+class FileAttachmentTest extends TestCase
 {
     /**
      * Gets Json String of Object FileAttachment

--- a/tests/PayPal/Test/Api/FlowConfigTest.php
+++ b/tests/PayPal/Test/Api/FlowConfigTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\FlowConfig;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FlowConfig
  *
  * @package PayPal\Test\Api
  */
-class FlowConfigTest extends \PHPUnit_Framework_TestCase
+class FlowConfigTest extends TestCase
 {
     /**
      * Gets Json String of Object FlowConfig

--- a/tests/PayPal/Test/Api/FmfDetailsTest.php
+++ b/tests/PayPal/Test/Api/FmfDetailsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\FmfDetails;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FmfDetails
  *
  * @package PayPal\Test\Api
  */
-class FmfDetailsTest extends \PHPUnit_Framework_TestCase
+class FmfDetailsTest extends TestCase
 {
     /**
      * Gets Json String of Object FmfDetails

--- a/tests/PayPal/Test/Api/FundingDetailTest.php
+++ b/tests/PayPal/Test/Api/FundingDetailTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\FundingDetail;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FundingDetail
  *
  * @package PayPal\Test\Api
  */
-class FundingDetailTest extends \PHPUnit_Framework_TestCase
+class FundingDetailTest extends TestCase
 {
     /**
      * Gets Json String of Object FundingDetail

--- a/tests/PayPal/Test/Api/FundingInstrumentTest.php
+++ b/tests/PayPal/Test/Api/FundingInstrumentTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\FundingInstrument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FundingInstrument
  *
  * @package PayPal\Test\Api
  */
-class FundingInstrumentTest extends \PHPUnit_Framework_TestCase
+class FundingInstrumentTest extends TestCase
 {
     /**
      * Gets Json String of Object FundingInstrument

--- a/tests/PayPal/Test/Api/FundingOptionTest.php
+++ b/tests/PayPal/Test/Api/FundingOptionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\FundingOption;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FundingOption
  *
  * @package PayPal\Test\Api
  */
-class FundingOptionTest extends \PHPUnit_Framework_TestCase
+class FundingOptionTest extends TestCase
 {
     /**
      * Gets Json String of Object FundingOption

--- a/tests/PayPal/Test/Api/FundingSourceTest.php
+++ b/tests/PayPal/Test/Api/FundingSourceTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\FundingSource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FundingSource
  *
  * @package PayPal\Test\Api
  */
-class FundingSourceTest extends \PHPUnit_Framework_TestCase
+class FundingSourceTest extends TestCase
 {
     /**
      * Gets Json String of Object FundingSource

--- a/tests/PayPal/Test/Api/HyperSchemaTest.php
+++ b/tests/PayPal/Test/Api/HyperSchemaTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\HyperSchema;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class HyperSchema
  *
  * @package PayPal\Test\Api
  */
-class HyperSchemaTest extends \PHPUnit_Framework_TestCase
+class HyperSchemaTest extends TestCase
 {
     /**
      * Gets Json String of Object HyperSchema

--- a/tests/PayPal/Test/Api/ImageTest.php
+++ b/tests/PayPal/Test/Api/ImageTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Image;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Image
  *
  * @package PayPal\Test\Api
  */
-class ImageTest extends \PHPUnit_Framework_TestCase
+class ImageTest extends TestCase
 {
     /**
      * Gets Json String of Object Patch

--- a/tests/PayPal/Test/Api/IncentiveTest.php
+++ b/tests/PayPal/Test/Api/IncentiveTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Incentive;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Incentive
  *
  * @package PayPal\Test\Api
  */
-class IncentiveTest extends \PHPUnit_Framework_TestCase
+class IncentiveTest extends TestCase
 {
     /**
      * Gets Json String of Object Incentive

--- a/tests/PayPal/Test/Api/InputFieldsTest.php
+++ b/tests/PayPal/Test/Api/InputFieldsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\InputFields;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InputFields
  *
  * @package PayPal\Test\Api
  */
-class InputFieldsTest extends \PHPUnit_Framework_TestCase
+class InputFieldsTest extends TestCase
 {
     /**
      * Gets Json String of Object InputFields

--- a/tests/PayPal/Test/Api/InstallmentInfoTest.php
+++ b/tests/PayPal/Test/Api/InstallmentInfoTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\InstallmentInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InstallmentInfo
  *
  * @package PayPal\Test\Api
  */
-class InstallmentInfoTest extends \PHPUnit_Framework_TestCase
+class InstallmentInfoTest extends TestCase
 {
     /**
      * Gets Json String of Object InstallmentInfo

--- a/tests/PayPal/Test/Api/InstallmentOptionTest.php
+++ b/tests/PayPal/Test/Api/InstallmentOptionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\InstallmentOption;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InstallmentOption
  *
  * @package PayPal\Test\Api
  */
-class InstallmentOptionTest extends \PHPUnit_Framework_TestCase
+class InstallmentOptionTest extends TestCase
 {
     /**
      * Gets Json String of Object InstallmentOption

--- a/tests/PayPal/Test/Api/InvoiceAddressTest.php
+++ b/tests/PayPal/Test/Api/InvoiceAddressTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\InvoiceAddress;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InvoiceAddress
  *
  * @package PayPal\Test\Api
  */
-class InvoiceAddressTest extends \PHPUnit_Framework_TestCase
+class InvoiceAddressTest extends TestCase
 {
     /**
      * Gets Json String of Object Address

--- a/tests/PayPal/Test/Api/InvoiceItemTest.php
+++ b/tests/PayPal/Test/Api/InvoiceItemTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\InvoiceItem;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InvoiceItem
  *
  * @package PayPal\Test\Api
  */
-class InvoiceItemTest extends \PHPUnit_Framework_TestCase
+class InvoiceItemTest extends TestCase
 {
     /**
      * Gets Json String of Object InvoiceItem

--- a/tests/PayPal/Test/Api/InvoiceNumberTest.php
+++ b/tests/PayPal/Test/Api/InvoiceNumberTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\InvoiceNumber;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Cost
  *
  * @package PayPal\Test\Api
  */
-class InvoiceNumberTest extends \PHPUnit_Framework_TestCase
+class InvoiceNumberTest extends TestCase
 {
     /**
      * Gets Json String of Object Cost

--- a/tests/PayPal/Test/Api/InvoiceSearchResponseTest.php
+++ b/tests/PayPal/Test/Api/InvoiceSearchResponseTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\InvoiceSearchResponse;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InvoiceSearchResponse
  *
  * @package PayPal\Test\Api
  */
-class InvoiceSearchResponseTest extends \PHPUnit_Framework_TestCase
+class InvoiceSearchResponseTest extends TestCase
 {
     /**
      * Gets Json String of Object InvoiceSearchResponse

--- a/tests/PayPal/Test/Api/InvoiceTest.php
+++ b/tests/PayPal/Test/Api/InvoiceTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Api\Invoice;
 use PayPal\Api\InvoiceNumber;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Invoice
  *
  * @package PayPal\Test\Api
  */
-class InvoiceTest extends \PHPUnit_Framework_TestCase
+class InvoiceTest extends TestCase
 {
     /**
      * Gets Json String of Object Invoice

--- a/tests/PayPal/Test/Api/ItemListTest.php
+++ b/tests/PayPal/Test/Api/ItemListTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ItemList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ItemList
  *
  * @package PayPal\Test\Api
  */
-class ItemListTest extends \PHPUnit_Framework_TestCase
+class ItemListTest extends TestCase
 {
     /**
      * Gets Json String of Object ItemList

--- a/tests/PayPal/Test/Api/ItemTest.php
+++ b/tests/PayPal/Test/Api/ItemTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Item;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Item
  *
  * @package PayPal\Test\Api
  */
-class ItemTest extends \PHPUnit_Framework_TestCase
+class ItemTest extends TestCase
 {
     /**
      * Gets Json String of Object Item

--- a/tests/PayPal/Test/Api/LinksTest.php
+++ b/tests/PayPal/Test/Api/LinksTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Links;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Links
  *
  * @package PayPal\Test\Api
  */
-class LinksTest extends \PHPUnit_Framework_TestCase
+class LinksTest extends TestCase
 {
     /**
      * Gets Json String of Object Links

--- a/tests/PayPal/Test/Api/MeasurementTest.php
+++ b/tests/PayPal/Test/Api/MeasurementTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Measurement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Measurement
  *
  * @package PayPal\Test\Api
  */
-class MeasurementTest extends \PHPUnit_Framework_TestCase
+class MeasurementTest extends TestCase
 {
     /**
      * Gets Json String of Object Measurement

--- a/tests/PayPal/Test/Api/MerchantInfoTest.php
+++ b/tests/PayPal/Test/Api/MerchantInfoTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\MerchantInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MerchantInfo
  *
  * @package PayPal\Test\Api
  */
-class MerchantInfoTest extends \PHPUnit_Framework_TestCase
+class MerchantInfoTest extends TestCase
 {
     /**
      * Gets Json String of Object MerchantInfo

--- a/tests/PayPal/Test/Api/MerchantPreferencesTest.php
+++ b/tests/PayPal/Test/Api/MerchantPreferencesTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\MerchantPreferences;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MerchantPreferences
  *
  * @package PayPal\Test\Api
  */
-class MerchantPreferencesTest extends \PHPUnit_Framework_TestCase
+class MerchantPreferencesTest extends TestCase
 {
     /**
      * Gets Json String of Object MerchantPreferences

--- a/tests/PayPal/Test/Api/MetadataTest.php
+++ b/tests/PayPal/Test/Api/MetadataTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Metadata;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Metadata
  *
  * @package PayPal\Test\Api
  */
-class MetadataTest extends \PHPUnit_Framework_TestCase
+class MetadataTest extends TestCase
 {
     /**
      * Gets Json String of Object Metadata

--- a/tests/PayPal/Test/Api/NameValuePairTest.php
+++ b/tests/PayPal/Test/Api/NameValuePairTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\NameValuePair;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class NameValuePair
  *
  * @package PayPal\Test\Api
  */
-class NameValuePairTest extends \PHPUnit_Framework_TestCase
+class NameValuePairTest extends TestCase
 {
     /**
      * Gets Json String of Object NameValuePair

--- a/tests/PayPal/Test/Api/NotificationTest.php
+++ b/tests/PayPal/Test/Api/NotificationTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Notification;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Notification
  *
  * @package PayPal\Test\Api
  */
-class NotificationTest extends \PHPUnit_Framework_TestCase
+class NotificationTest extends TestCase
 {
     /**
      * Gets Json String of Object Notification

--- a/tests/PayPal/Test/Api/OpenIdAddressTest.php
+++ b/tests/PayPal/Test/Api/OpenIdAddressTest.php
@@ -2,12 +2,13 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\OpenIdAddress;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for OpenIdAddress.
  *
  */
-class OpenIdAddressTest extends \PHPUnit_Framework_TestCase
+class OpenIdAddressTest extends TestCase
 {
 
     /** @var  OpenIdAddress */
@@ -28,14 +29,15 @@ class OpenIdAddressTest extends \PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
+
     }
 
     public static function getTestData()
     {
         $addr = new OpenIdAddress();
         $addr->setCountry("US")->setLocality("San Jose")
-            ->setPostalCode("95112")->setRegion("CA")
-            ->setStreetAddress("1, North 1'st street");
+                ->setPostalCode("95112")->setRegion("CA")
+                ->setStreetAddress("1, North 1'st street");
         return $addr;
     }
 
@@ -49,4 +51,5 @@ class OpenIdAddressTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->addr, $addrCopy);
     }
+
 }

--- a/tests/PayPal/Test/Api/OpenIdErrorTest.php
+++ b/tests/PayPal/Test/Api/OpenIdErrorTest.php
@@ -3,12 +3,13 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\OpenIdError;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for OpenIdError.
  *
  */
-class OpenIdErrorTest extends \PHPUnit_Framework_TestCase
+class OpenIdErrorTest extends TestCase
 {
 
     /** @var  OpenIdError */

--- a/tests/PayPal/Test/Api/OpenIdSessionTest.php
+++ b/tests/PayPal/Test/Api/OpenIdSessionTest.php
@@ -4,12 +4,13 @@ namespace PayPal\Test\Api;
 
 use PayPal\Api\OpenIdSession;
 use PayPal\Rest\ApiContext;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for OpenIdSession.
  *
  */
-class OpenIdSessionTest extends \PHPUnit_Framework_TestCase
+class OpenIdSessionTest extends TestCase
 {
 
     private $context;

--- a/tests/PayPal/Test/Api/OpenIdTokeninfoTest.php
+++ b/tests/PayPal/Test/Api/OpenIdTokeninfoTest.php
@@ -2,12 +2,13 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\OpenIdTokeninfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for OpenIdTokeninfo.
  *
  */
-class OpenIdTokeninfoTest extends \PHPUnit_Framework_TestCase
+class OpenIdTokeninfoTest extends TestCase
 {
 
     /** @var  OpenIdTokeninfo */

--- a/tests/PayPal/Test/Api/OpenIdUserinfoTest.php
+++ b/tests/PayPal/Test/Api/OpenIdUserinfoTest.php
@@ -3,12 +3,13 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\OpenIdUserinfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for OpenIdUserinfo.
  *
  */
-class OpenIdUserinfoTest extends \PHPUnit_Framework_TestCase
+class OpenIdUserinfoTest extends TestCase
 {
 
 

--- a/tests/PayPal/Test/Api/OrderTest.php
+++ b/tests/PayPal/Test/Api/OrderTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Api\Authorization;
 use PayPal\Api\Order;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Order
  *
  * @package PayPal\Test\Api
  */
-class OrderTest extends \PHPUnit_Framework_TestCase
+class OrderTest extends TestCase
 {
     /**
      * Gets Json String of Object Order

--- a/tests/PayPal/Test/Api/OverrideChargeModelTest.php
+++ b/tests/PayPal/Test/Api/OverrideChargeModelTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\OverrideChargeModel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class OverrideChargeModel
  *
  * @package PayPal\Test\Api
  */
-class OverrideChargeModelTest extends \PHPUnit_Framework_TestCase
+class OverrideChargeModelTest extends TestCase
 {
     /**
      * Gets Json String of Object OverrideChargeModel

--- a/tests/PayPal/Test/Api/ParticipantTest.php
+++ b/tests/PayPal/Test/Api/ParticipantTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\Participant;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Participant
  *
  * @package PayPal\Test\Api
  */
-class ParticipantTest extends \PHPUnit_Framework_TestCase
+class ParticipantTest extends TestCase
 {
     /**
      * Gets Json String of Object Participant

--- a/tests/PayPal/Test/Api/PatchRequestTest.php
+++ b/tests/PayPal/Test/Api/PatchRequestTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\PatchRequest;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PatchRequest
  *
  * @package PayPal\Test\Api
  */
-class PatchRequestTest extends \PHPUnit_Framework_TestCase
+class PatchRequestTest extends TestCase
 {
     /**
      * Gets Json String of Object PatchRequest

--- a/tests/PayPal/Test/Api/PatchTest.php
+++ b/tests/PayPal/Test/Api/PatchTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\Patch;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Patch
  *
  * @package PayPal\Test\Api
  */
-class PatchTest extends \PHPUnit_Framework_TestCase
+class PatchTest extends TestCase
 {
     /**
      * Gets Json String of Object Patch

--- a/tests/PayPal/Test/Api/PayeeTest.php
+++ b/tests/PayPal/Test/Api/PayeeTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Payee;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Payee
  *
  * @package PayPal\Test\Api
  */
-class PayeeTest extends \PHPUnit_Framework_TestCase
+class PayeeTest extends TestCase
 {
     /**
      * Gets Json String of Object Payee

--- a/tests/PayPal/Test/Api/PayerInfoTest.php
+++ b/tests/PayPal/Test/Api/PayerInfoTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PayerInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PayerInfo
  *
  * @package PayPal\Test\Api
  */
-class PayerInfoTest extends \PHPUnit_Framework_TestCase
+class PayerInfoTest extends TestCase
 {
     /**
      * Gets Json String of Object PayerInfo

--- a/tests/PayPal/Test/Api/PayerTest.php
+++ b/tests/PayPal/Test/Api/PayerTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Payer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Payer
  *
  * @package PayPal\Test\Api
  */
-class PayerTest extends \PHPUnit_Framework_TestCase
+class PayerTest extends TestCase
 {
     /**
      * Gets Json String of Object Payer

--- a/tests/PayPal/Test/Api/PaymentCardTest.php
+++ b/tests/PayPal/Test/Api/PaymentCardTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentCard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentCard
  *
  * @package PayPal\Test\Api
  */
-class PaymentCardTest extends \PHPUnit_Framework_TestCase
+class PaymentCardTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentCard

--- a/tests/PayPal/Test/Api/PaymentCardTokenTest.php
+++ b/tests/PayPal/Test/Api/PaymentCardTokenTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentCardToken;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentCardToken
  *
  * @package PayPal\Test\Api
  */
-class PaymentCardTokenTest extends \PHPUnit_Framework_TestCase
+class PaymentCardTokenTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentCardToken

--- a/tests/PayPal/Test/Api/PaymentDefinitionTest.php
+++ b/tests/PayPal/Test/Api/PaymentDefinitionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentDefinition
  *
  * @package PayPal\Test\Api
  */
-class PaymentDefinitionTest extends \PHPUnit_Framework_TestCase
+class PaymentDefinitionTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentDefinition

--- a/tests/PayPal/Test/Api/PaymentDetailTest.php
+++ b/tests/PayPal/Test/Api/PaymentDetailTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentDetail;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentDetail
  *
  * @package PayPal\Test\Api
  */
-class PaymentDetailTest extends \PHPUnit_Framework_TestCase
+class PaymentDetailTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentDetail

--- a/tests/PayPal/Test/Api/PaymentExecutionTest.php
+++ b/tests/PayPal/Test/Api/PaymentExecutionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentExecution;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentExecution
  *
  * @package PayPal\Test\Api
  */
-class PaymentExecutionTest extends \PHPUnit_Framework_TestCase
+class PaymentExecutionTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentExecution

--- a/tests/PayPal/Test/Api/PaymentHistoryTest.php
+++ b/tests/PayPal/Test/Api/PaymentHistoryTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentHistory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentHistory
  *
  * @package PayPal\Test\Api
  */
-class PaymentHistoryTest extends \PHPUnit_Framework_TestCase
+class PaymentHistoryTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentHistory

--- a/tests/PayPal/Test/Api/PaymentInstructionTest.php
+++ b/tests/PayPal/Test/Api/PaymentInstructionTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentInstruction;
 use PayPal\Transport\PPRestCall;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentInstruction
  *
  * @package PayPal\Test\Api
  */
-class PaymentInstructionTest extends \PHPUnit_Framework_TestCase
+class PaymentInstructionTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentInstruction

--- a/tests/PayPal/Test/Api/PaymentOptionsTest.php
+++ b/tests/PayPal/Test/Api/PaymentOptionsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentOptions
  *
  * @package PayPal\Test\Api
  */
-class PaymentOptionsTest extends \PHPUnit_Framework_TestCase
+class PaymentOptionsTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentOptions

--- a/tests/PayPal/Test/Api/PaymentSummaryTest.php
+++ b/tests/PayPal/Test/Api/PaymentSummaryTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\PaymentSummary;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentSummary
  *
  * @package PayPal\Test\Api
  */
-class PaymentSummaryTest extends \PHPUnit_Framework_TestCase
+class PaymentSummaryTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentSummary

--- a/tests/PayPal/Test/Api/PaymentTermTest.php
+++ b/tests/PayPal/Test/Api/PaymentTermTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PaymentTerm;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaymentTerm
  *
  * @package PayPal\Test\Api
  */
-class PaymentTermTest extends \PHPUnit_Framework_TestCase
+class PaymentTermTest extends TestCase
 {
     /**
      * Gets Json String of Object PaymentTerm

--- a/tests/PayPal/Test/Api/PaymentTest.php
+++ b/tests/PayPal/Test/Api/PaymentTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Payment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Payment
  *
  * @package PayPal\Test\Api
  */
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
     /**
      * Gets Json String of Object Payment

--- a/tests/PayPal/Test/Api/PayoutBatchHeaderTest.php
+++ b/tests/PayPal/Test/Api/PayoutBatchHeaderTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PayoutBatchHeader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PayoutBatchHeader
  *
  * @package PayPal\Test\Api
  */
-class PayoutBatchHeaderTest extends \PHPUnit_Framework_TestCase
+class PayoutBatchHeaderTest extends TestCase
 {
     /**
      * Gets Json String of Object PayoutBatchHeader

--- a/tests/PayPal/Test/Api/PayoutBatchTest.php
+++ b/tests/PayPal/Test/Api/PayoutBatchTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PayoutBatch;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PayoutBatch
  *
  * @package PayPal\Test\Api
  */
-class PayoutBatchTest extends \PHPUnit_Framework_TestCase
+class PayoutBatchTest extends TestCase
 {
     /**
      * Gets Json String of Object PayoutBatch

--- a/tests/PayPal/Test/Api/PayoutItemDetailsTest.php
+++ b/tests/PayPal/Test/Api/PayoutItemDetailsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PayoutItemDetails;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PayoutItemDetails
  *
  * @package PayPal\Test\Api
  */
-class PayoutItemDetailsTest extends \PHPUnit_Framework_TestCase
+class PayoutItemDetailsTest extends TestCase
 {
     /**
      * Gets Json String of Object PayoutItemDetails

--- a/tests/PayPal/Test/Api/PayoutItemTest.php
+++ b/tests/PayPal/Test/Api/PayoutItemTest.php
@@ -5,13 +5,14 @@ namespace PayPal\Test\Api;
 use PayPal\Api\ItemsArray;
 use PayPal\Api\PayoutItem;
 use PayPal\Transport\PPRestCall;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PayoutItem
  *
  * @package PayPal\Test\Api
  */
-class PayoutItemTest extends \PHPUnit_Framework_TestCase
+class PayoutItemTest extends TestCase
 {
     /**
      * Gets Json String of Object PayoutItem

--- a/tests/PayPal/Test/Api/PayoutSenderBatchHeaderTest.php
+++ b/tests/PayPal/Test/Api/PayoutSenderBatchHeaderTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\PayoutSenderBatchHeader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PayoutSenderBatchHeader
  *
  * @package PayPal\Test\Api
  */
-class PayoutSenderBatchHeaderTest extends \PHPUnit_Framework_TestCase
+class PayoutSenderBatchHeaderTest extends TestCase
 {
     /**
      * Gets Json String of Object PayoutSenderBatchHeader

--- a/tests/PayPal/Test/Api/PayoutTest.php
+++ b/tests/PayPal/Test/Api/PayoutTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Payout;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Payout
  *
  * @package PayPal\Test\Api
  */
-class PayoutTest extends \PHPUnit_Framework_TestCase
+class PayoutTest extends TestCase
 {
     /**
      * Gets Json String of Object Payout

--- a/tests/PayPal/Test/Api/PhoneTest.php
+++ b/tests/PayPal/Test/Api/PhoneTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Phone;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Phone
  *
  * @package PayPal\Test\Api
  */
-class PhoneTest extends \PHPUnit_Framework_TestCase
+class PhoneTest extends TestCase
 {
     /**
      * Gets Json String of Object Phone

--- a/tests/PayPal/Test/Api/PlanListTest.php
+++ b/tests/PayPal/Test/Api/PlanListTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PlanList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PlanList
  *
  * @package PayPal\Test\Api
  */
-class PlanListTest extends \PHPUnit_Framework_TestCase
+class PlanListTest extends TestCase
 {
     /**
      * Gets Json String of Object PlanList

--- a/tests/PayPal/Test/Api/PlanTest.php
+++ b/tests/PayPal/Test/Api/PlanTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Plan;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Plan
  *
  * @package PayPal\Test\Api
  */
-class PlanTest extends \PHPUnit_Framework_TestCase
+class PlanTest extends TestCase
 {
     /**
      * Gets Json String of Object Plan

--- a/tests/PayPal/Test/Api/PotentialPayerInfoTest.php
+++ b/tests/PayPal/Test/Api/PotentialPayerInfoTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PotentialPayerInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PotentialPayerInfo
  *
  * @package PayPal\Test\Api
  */
-class PotentialPayerInfoTest extends \PHPUnit_Framework_TestCase
+class PotentialPayerInfoTest extends TestCase
 {
     /**
      * Gets Json String of Object PotentialPayerInfo

--- a/tests/PayPal/Test/Api/PresentationTest.php
+++ b/tests/PayPal/Test/Api/PresentationTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Presentation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Presentation
  *
  * @package PayPal\Test\Api
  */
-class PresentationTest extends \PHPUnit_Framework_TestCase
+class PresentationTest extends TestCase
 {
     /**
      * Gets Json String of Object Presentation

--- a/tests/PayPal/Test/Api/PrivateLabelCardTest.php
+++ b/tests/PayPal/Test/Api/PrivateLabelCardTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\PrivateLabelCard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PrivateLabelCard
  *
  * @package PayPal\Test\Api
  */
-class PrivateLabelCardTest extends \PHPUnit_Framework_TestCase
+class PrivateLabelCardTest extends TestCase
 {
     /**
      * Gets Json String of Object PrivateLabelCard

--- a/tests/PayPal/Test/Api/ProcessorResponseTest.php
+++ b/tests/PayPal/Test/Api/ProcessorResponseTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ProcessorResponse;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ProcessorResponse
  *
  * @package PayPal\Test\Api
  */
-class ProcessorResponseTest extends \PHPUnit_Framework_TestCase
+class ProcessorResponseTest extends TestCase
 {
     /**
      * Gets Json String of Object ProcessorResponse

--- a/tests/PayPal/Test/Api/RecipientBankingInstructionTest.php
+++ b/tests/PayPal/Test/Api/RecipientBankingInstructionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\RecipientBankingInstruction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RecipientBankingInstruction
  *
  * @package PayPal\Test\Api
  */
-class RecipientBankingInstructionTest extends \PHPUnit_Framework_TestCase
+class RecipientBankingInstructionTest extends TestCase
 {
     /**
      * Gets Json String of Object RecipientBankingInstruction

--- a/tests/PayPal/Test/Api/RedirectUrlsTest.php
+++ b/tests/PayPal/Test/Api/RedirectUrlsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\RedirectUrls;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RedirectUrls
  *
  * @package PayPal\Test\Api
  */
-class RedirectUrlsTest extends \PHPUnit_Framework_TestCase
+class RedirectUrlsTest extends TestCase
 {
     /**
      * Gets Json String of Object RedirectUrls

--- a/tests/PayPal/Test/Api/RefundDetailTest.php
+++ b/tests/PayPal/Test/Api/RefundDetailTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\RefundDetail;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RefundDetail
  *
  * @package PayPal\Test\Api
  */
-class RefundDetailTest extends \PHPUnit_Framework_TestCase
+class RefundDetailTest extends TestCase
 {
     /**
      * Gets Json String of Object RefundDetail

--- a/tests/PayPal/Test/Api/RefundRequestTest.php
+++ b/tests/PayPal/Test/Api/RefundRequestTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\RefundRequest;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RefundRequest
  *
  * @package PayPal\Test\Api
  */
-class RefundRequestTest extends \PHPUnit_Framework_TestCase
+class RefundRequestTest extends TestCase
 {
     /**
      * Gets Json String of Object RefundRequest

--- a/tests/PayPal/Test/Api/RefundTest.php
+++ b/tests/PayPal/Test/Api/RefundTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Refund;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Refund
  *
  * @package PayPal\Test\Api
  */
-class RefundTest extends \PHPUnit_Framework_TestCase
+class RefundTest extends TestCase
 {
     /**
      * Gets Json String of Object Refund

--- a/tests/PayPal/Test/Api/RelatedResourcesTest.php
+++ b/tests/PayPal/Test/Api/RelatedResourcesTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\RelatedResources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class RelatedResources
  *
  * @package PayPal\Test\Api
  */
-class RelatedResourcesTest extends \PHPUnit_Framework_TestCase
+class RelatedResourcesTest extends TestCase
 {
     /**
      * Gets Json String of Object RelatedResources

--- a/tests/PayPal/Test/Api/SaleTest.php
+++ b/tests/PayPal/Test/Api/SaleTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Sale;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Sale
  *
  * @package PayPal\Test\Api
  */
-class SaleTest extends \PHPUnit_Framework_TestCase
+class SaleTest extends TestCase
 {
     /**
      * Gets Json String of Object Sale

--- a/tests/PayPal/Test/Api/SearchTest.php
+++ b/tests/PayPal/Test/Api/SearchTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Search;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Search
  *
  * @package PayPal\Test\Api
  */
-class SearchTest extends \PHPUnit_Framework_TestCase
+class SearchTest extends TestCase
 {
     /**
      * Gets Json String of Object Search

--- a/tests/PayPal/Test/Api/ShippingAddressTest.php
+++ b/tests/PayPal/Test/Api/ShippingAddressTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ShippingAddress;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ShippingAddress
  *
  * @package PayPal\Test\Api
  */
-class ShippingAddressTest extends \PHPUnit_Framework_TestCase
+class ShippingAddressTest extends TestCase
 {
     /**
      * Gets Json String of Object ShippingAddress

--- a/tests/PayPal/Test/Api/ShippingCostTest.php
+++ b/tests/PayPal/Test/Api/ShippingCostTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ShippingCost;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ShippingCost
  *
  * @package PayPal\Test\Api
  */
-class ShippingCostTest extends \PHPUnit_Framework_TestCase
+class ShippingCostTest extends TestCase
 {
     /**
      * Gets Json String of Object ShippingCost

--- a/tests/PayPal/Test/Api/ShippingInfoTest.php
+++ b/tests/PayPal/Test/Api/ShippingInfoTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\ShippingInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ShippingInfo
  *
  * @package PayPal\Test\Api
  */
-class ShippingInfoTest extends \PHPUnit_Framework_TestCase
+class ShippingInfoTest extends TestCase
 {
     /**
      * Gets Json String of Object ShippingInfo

--- a/tests/PayPal/Test/Api/TaxTest.php
+++ b/tests/PayPal/Test/Api/TaxTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Tax;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Tax
  *
  * @package PayPal\Test\Api
  */
-class TaxTest extends \PHPUnit_Framework_TestCase
+class TaxTest extends TestCase
 {
     /**
      * Gets Json String of Object Tax

--- a/tests/PayPal/Test/Api/TemplateDataTest.php
+++ b/tests/PayPal/Test/Api/TemplateDataTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\TemplateData;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class TemplateData
  *
  * @package PayPal\Test\Api
  */
-class TemplateDataTest extends \PHPUnit_Framework_TestCase
+class TemplateDataTest extends TestCase
 {
     /**
      * Gets Json String of Object TemplateData

--- a/tests/PayPal/Test/Api/TemplateSettingsMetadataTest.php
+++ b/tests/PayPal/Test/Api/TemplateSettingsMetadataTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\TemplateSettingsMetadata;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class TemplateSettingsMetadata
  *
  * @package PayPal\Test\Api
  */
-class TemplateSettingsMetadataTest extends \PHPUnit_Framework_TestCase
+class TemplateSettingsMetadataTest extends TestCase
 {
     /**
      * Gets Json String of Object TemplateSettingsMetadata

--- a/tests/PayPal/Test/Api/TemplateSettingsTest.php
+++ b/tests/PayPal/Test/Api/TemplateSettingsTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\TemplateSettings;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class TemplateSettings
  *
  * @package PayPal\Test\Api
  */
-class TemplateSettingsTest extends \PHPUnit_Framework_TestCase
+class TemplateSettingsTest extends TestCase
 {
     /**
      * Gets Json String of Object TemplateSettings

--- a/tests/PayPal/Test/Api/TemplateTest.php
+++ b/tests/PayPal/Test/Api/TemplateTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\Template;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Template
  *
  * @package PayPal\Test\Api
  */
-class TemplateTest extends \PHPUnit_Framework_TestCase
+class TemplateTest extends TestCase
 {
     /**
      * Gets Json String of Object Template

--- a/tests/PayPal/Test/Api/TemplatesTest.php
+++ b/tests/PayPal/Test/Api/TemplatesTest.php
@@ -7,13 +7,14 @@ use PayPal\Validation\ArgumentValidator;
 use PayPal\Api\Template;
 use PayPal\Rest\ApiContext;
 use PayPal\Api\Templates;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Templates
  *
  * @package PayPal\Test\Api
  */
-class TemplatesTest extends \PHPUnit_Framework_TestCase
+class TemplatesTest extends TestCase
 {
     /**
      * Gets Json String of Object Templates

--- a/tests/PayPal/Test/Api/TermsTest.php
+++ b/tests/PayPal/Test/Api/TermsTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Terms;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Terms
  *
  * @package PayPal\Test\Api
  */
-class TermsTest extends \PHPUnit_Framework_TestCase
+class TermsTest extends TestCase
 {
     /**
      * Gets Json String of Object Terms

--- a/tests/PayPal/Test/Api/TransactionTest.php
+++ b/tests/PayPal/Test/Api/TransactionTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\Transaction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Transaction
  *
  * @package PayPal\Test\Api
  */
-class TransactionTest extends \PHPUnit_Framework_TestCase
+class TransactionTest extends TestCase
 {
     /**
      * Gets Json String of Object Transaction

--- a/tests/PayPal/Test/Api/VerifyWebhookSignatureResponseTest.php
+++ b/tests/PayPal/Test/Api/VerifyWebhookSignatureResponseTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\VerifyWebhookSignatureResponse;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class VerifyWebhookSignatureResponse
  *
  * @package PayPal\Test\Api
  */
-class VerifyWebhookSignatureResponseTest extends \PHPUnit_Framework_TestCase
+class VerifyWebhookSignatureResponseTest extends TestCase
 {
     /**
      * Gets Json String of Object VerifyWebhookSignatureResponse

--- a/tests/PayPal/Test/Api/VerifyWebhookSignatureTest.php
+++ b/tests/PayPal/Test/Api/VerifyWebhookSignatureTest.php
@@ -7,13 +7,14 @@ use PayPal\Validation\ArgumentValidator;
 use PayPal\Api\VerifyWebhookSignatureResponse;
 use PayPal\Rest\ApiContext;
 use PayPal\Api\VerifyWebhookSignature;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class VerifyWebhookSignature
  *
  * @package PayPal\Test\Api
  */
-class VerifyWebhookSignatureTest extends \PHPUnit_Framework_TestCase
+class VerifyWebhookSignatureTest extends TestCase
 {
     /**
      * Gets Json String of Object VerifyWebhookSignature

--- a/tests/PayPal/Test/Api/WebProfileTest.php
+++ b/tests/PayPal/Test/Api/WebProfileTest.php
@@ -3,13 +3,14 @@
 namespace PayPal\Test\Api;
 
 use PayPal\Api\WebProfile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebProfile
  *
  * @package PayPal\Test\Api
  */
-class WebProfileTest extends \PHPUnit_Framework_TestCase
+class WebProfileTest extends TestCase
 {
     /**
      * Gets Json String of Object WebProfile

--- a/tests/PayPal/Test/Api/WebhookEventListTest.php
+++ b/tests/PayPal/Test/Api/WebhookEventListTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\WebhookEventList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebhookEventList
  *
  * @package PayPal\Test\Api
  */
-class WebhookEventListTest extends \PHPUnit_Framework_TestCase
+class WebhookEventListTest extends TestCase
 {
     /**
      * Gets Json String of Object WebhookEventList

--- a/tests/PayPal/Test/Api/WebhookEventTest.php
+++ b/tests/PayPal/Test/Api/WebhookEventTest.php
@@ -7,13 +7,14 @@ use PayPal\Validation\ArgumentValidator;
 use PayPal\Api\WebhookEventList;
 use PayPal\Rest\ApiContext;
 use PayPal\Api\WebhookEvent;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebhookEvent
  *
  * @package PayPal\Test\Api
  */
-class WebhookEventTest extends \PHPUnit_Framework_TestCase
+class WebhookEventTest extends TestCase
 {
     /**
      * Gets Json String of Object WebhookEvent

--- a/tests/PayPal/Test/Api/WebhookEventTypeListTest.php
+++ b/tests/PayPal/Test/Api/WebhookEventTypeListTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\WebhookEventTypeList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebhookEventTypeList
  *
  * @package PayPal\Test\Api
  */
-class WebhookEventTypeListTest extends \PHPUnit_Framework_TestCase
+class WebhookEventTypeListTest extends TestCase
 {
     /**
      * Gets Json String of Object WebhookEventTypeList

--- a/tests/PayPal/Test/Api/WebhookEventTypeTest.php
+++ b/tests/PayPal/Test/Api/WebhookEventTypeTest.php
@@ -7,13 +7,14 @@ use PayPal\Validation\ArgumentValidator;
 use PayPal\Api\WebhookEventTypeList;
 use PayPal\Rest\ApiContext;
 use PayPal\Api\WebhookEventType;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebhookEventType
  *
  * @package PayPal\Test\Api
  */
-class WebhookEventTypeTest extends \PHPUnit_Framework_TestCase
+class WebhookEventTypeTest extends TestCase
 {
     /**
      * Gets Json String of Object WebhookEventType

--- a/tests/PayPal/Test/Api/WebhookListTest.php
+++ b/tests/PayPal/Test/Api/WebhookListTest.php
@@ -4,13 +4,14 @@ namespace PayPal\Test\Api;
 
 use PayPal\Common\PayPalModel;
 use PayPal\Api\WebhookList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebhookList
  *
  * @package PayPal\Test\Api
  */
-class WebhookListTest extends \PHPUnit_Framework_TestCase
+class WebhookListTest extends TestCase
 {
     /**
      * Gets Json String of Object WebhookList

--- a/tests/PayPal/Test/Api/WebhookTest.php
+++ b/tests/PayPal/Test/Api/WebhookTest.php
@@ -7,13 +7,14 @@ use PayPal\Validation\ArgumentValidator;
 use PayPal\Api\WebhookList;
 use PayPal\Rest\ApiContext;
 use PayPal\Api\Webhook;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Webhook
  *
  * @package PayPal\Test\Api
  */
-class WebhookTest extends \PHPUnit_Framework_TestCase
+class WebhookTest extends TestCase
 {
     /**
      * Gets Json String of Object Webhook

--- a/tests/PayPal/Test/Auth/OAuthTokenCredentialTest.php
+++ b/tests/PayPal/Test/Auth/OAuthTokenCredentialTest.php
@@ -8,8 +8,9 @@ use PayPal\Core\PayPalConfigManager;
 use PayPal\Rest\ApiContext;
 use PayPal\Test\Cache\AuthorizationCacheTest;
 use PayPal\Test\Constants;
+use PHPUnit\Framework\TestCase;
 
-class OAuthTokenCredentialTest extends \PHPUnit_Framework_TestCase
+class OAuthTokenCredentialTest extends TestCase
 {
 
     /**

--- a/tests/PayPal/Test/Cache/AuthorizationCacheTest.php
+++ b/tests/PayPal/Test/Cache/AuthorizationCacheTest.php
@@ -3,12 +3,13 @@
 namespace PayPal\Test\Cache;
 
 use PayPal\Cache\AuthorizationCache;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for AuthorizationCacheTest.
  *
  */
-class AuthorizationCacheTest extends \PHPUnit_Framework_TestCase
+class AuthorizationCacheTest extends TestCase
 {
     const CACHE_FILE = 'tests/var/test.cache';
 

--- a/tests/PayPal/Test/Common/ArrayUtilTest.php
+++ b/tests/PayPal/Test/Common/ArrayUtilTest.php
@@ -2,8 +2,9 @@
 namespace PayPal\Test\Common;
 
 use PayPal\Common\ArrayUtil;
+use PHPUnit\Framework\TestCase;
 
-class ArrayUtilTest extends \PHPUnit_Framework_TestCase
+class ArrayUtilTest extends TestCase
 {
 
     public function testIsAssocArray()

--- a/tests/PayPal/Test/Common/FormatConverterTest.php
+++ b/tests/PayPal/Test/Common/FormatConverterTest.php
@@ -10,8 +10,9 @@ use PayPal\Api\Tax;
 use PayPal\Common\PayPalModel;
 use PayPal\Converter\FormatConverter;
 use PayPal\Test\Validation\NumericValidatorTest;
+use PHPUnit\Framework\TestCase;
 
-class FormatConverterTest extends \PHPUnit_Framework_TestCase
+class FormatConverterTest extends TestCase
 {
 
     public static function classMethodListProvider()

--- a/tests/PayPal/Test/Common/ModelTest.php
+++ b/tests/PayPal/Test/Common/ModelTest.php
@@ -4,8 +4,9 @@ namespace PayPal\Test\Common;
 use PayPal\Api\Payment;
 use PayPal\Common\PayPalModel;
 use PayPal\Core\PayPalConfigManager;
+use PHPUnit\Framework\TestCase;
 
-class ModelTest extends \PHPUnit_Framework_TestCase
+class ModelTest extends TestCase
 {
 
     public function testSimpleClassConversion()

--- a/tests/PayPal/Test/Common/PayPalModelTest.php
+++ b/tests/PayPal/Test/Common/PayPalModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PayPal\Common\PayPalModel;
+use PHPUnit\Framework\TestCase;
 
 class SimpleModelTestClass extends PayPalModel
 {
@@ -145,7 +146,7 @@ class ListModelTestClass extends PayPalModel
  * Test class for PayPalModel.
  *
  */
-class PayPalModelTest extends PHPUnit_Framework_TestCase
+class PayPalModelTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/PayPal/Test/Common/UserAgentTest.php
+++ b/tests/PayPal/Test/Common/UserAgentTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PayPal\Common\PayPalUserAgent;
+use PHPUnit\Framework\TestCase;
 
-class UserAgentTest extends PHPUnit_Framework_TestCase
+class UserAgentTest extends TestCase
 {
 
     public function testGetValue()

--- a/tests/PayPal/Test/Core/PPConfigManagerTest.php.skipped
+++ b/tests/PayPal/Test/Core/PPConfigManagerTest.php.skipped
@@ -1,7 +1,8 @@
 <?php
 use PayPal\Core\PayPalConfigManager;
+use PHPUnit\Framework\TestCase;
 
-class PPConfigManagerTest extends \PHPUnit_Framework_TestCase
+class PPConfigManagerTest extends TestCase
 {
     /**
      * @var PayPalConfigManager

--- a/tests/PayPal/Test/Core/PayPalCredentialManagerTest.php
+++ b/tests/PayPal/Test/Core/PayPalCredentialManagerTest.php
@@ -1,12 +1,13 @@
 <?php
 use PayPal\Core\PayPalCredentialManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PayPalCredentialManager.
  *
  * @runTestsInSeparateProcesses
  */
-class PayPalCredentialManagerTest extends \PHPUnit_Framework_TestCase
+class PayPalCredentialManagerTest extends TestCase
 {
     /**
      * @var PayPalCredentialManager

--- a/tests/PayPal/Test/Core/PayPalHttpConfigTest.php
+++ b/tests/PayPal/Test/Core/PayPalHttpConfigTest.php
@@ -3,12 +3,13 @@
 namespace PayPal\Test\Core;
 
 use PayPal\Core\PayPalHttpConfig;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PayPalHttpConfigTest.
  *
  */
-class PayPalHttpConfigTest extends \PHPUnit_Framework_TestCase
+class PayPalHttpConfigTest extends TestCase
 {
 
     protected $object;

--- a/tests/PayPal/Test/Core/PayPalLoggingManagerTest.php
+++ b/tests/PayPal/Test/Core/PayPalLoggingManagerTest.php
@@ -1,11 +1,12 @@
 <?php
 use PayPal\Core\PayPalLoggingManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PayPalLoggingManager.
  *
  */
-class PayPalLoggingManagerTest extends \PHPUnit_Framework_TestCase
+class PayPalLoggingManagerTest extends TestCase
 {
     /**
      * @var PayPalLoggingManager

--- a/tests/PayPal/Test/Exception/PayPalConfigurationExceptionTest.php
+++ b/tests/PayPal/Test/Exception/PayPalConfigurationExceptionTest.php
@@ -1,11 +1,12 @@
 <?php
 use PayPal\Exception\PayPalConfigurationException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PayPalConfigurationException.
  *
  */
-class PayPalConfigurationExceptionTest extends \PHPUnit_Framework_TestCase
+class PayPalConfigurationExceptionTest extends TestCase
 {
     /**
      * @var PayPalConfigurationException

--- a/tests/PayPal/Test/Exception/PayPalConnectionExceptionTest.php
+++ b/tests/PayPal/Test/Exception/PayPalConnectionExceptionTest.php
@@ -1,11 +1,12 @@
 <?php
 use PayPal\Exception\PayPalConnectionException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PayPalConnectionException.
  *
  */
-class PayPalConnectionExceptionTest extends \PHPUnit_Framework_TestCase
+class PayPalConnectionExceptionTest extends TestCase
 {
     /**
      * @var PayPalConnectionException

--- a/tests/PayPal/Test/Exception/PayPalInvalidCredentialExceptionTest.php
+++ b/tests/PayPal/Test/Exception/PayPalInvalidCredentialExceptionTest.php
@@ -1,11 +1,12 @@
 <?php
 use PayPal\Exception\PayPalInvalidCredentialException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PayPalInvalidCredentialException.
  *
  */
-class PayPalInvalidCredentialExceptionTest extends \PHPUnit_Framework_TestCase
+class PayPalInvalidCredentialExceptionTest extends TestCase
 {
     /**
      * @var PayPalInvalidCredentialException

--- a/tests/PayPal/Test/Exception/PayPalMissingCredentialExceptionTest.php
+++ b/tests/PayPal/Test/Exception/PayPalMissingCredentialExceptionTest.php
@@ -1,11 +1,12 @@
 <?php
 use PayPal\Exception\PayPalMissingCredentialException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PayPalMissingCredentialException.
  *
  */
-class PayPalMissingCredentialExceptionTest extends \PHPUnit_Framework_TestCase
+class PayPalMissingCredentialExceptionTest extends TestCase
 {
     /**
      * @var PayPalMissingCredentialException

--- a/tests/PayPal/Test/Functional/Api/BillingAgreementsFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/BillingAgreementsFunctionalTest.php
@@ -9,13 +9,14 @@ use PayPal\Api\Patch;
 use PayPal\Api\PatchRequest;
 use PayPal\Api\Plan;
 use PayPal\Test\Functional\Setup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Billing Agreements
  *
  * @package PayPal\Test\Api
  */
-class BillingAgreementsFunctionalTest extends \PHPUnit_Framework_TestCase
+class BillingAgreementsFunctionalTest extends TestCase
 {
 
     public $operation;

--- a/tests/PayPal/Test/Functional/Api/BillingPlansFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/BillingPlansFunctionalTest.php
@@ -6,13 +6,14 @@ use PayPal\Api\Patch;
 use PayPal\Api\PatchRequest;
 use PayPal\Api\Plan;
 use PayPal\Test\Functional\Setup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Billing Plans
  *
  * @package PayPal\Test\Api
  */
-class BillingPlansFunctionalTest extends \PHPUnit_Framework_TestCase
+class BillingPlansFunctionalTest extends TestCase
 {
 
     public static $obj;

--- a/tests/PayPal/Test/Functional/Api/InvoiceFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/InvoiceFunctionalTest.php
@@ -9,13 +9,14 @@ use PayPal\Api\PaymentDetail;
 use PayPal\Api\RefundDetail;
 use PayPal\Api\Search;
 use PayPal\Test\Functional\Setup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Invoice
  *
  * @package PayPal\Test\Api
  */
-class InvoiceFunctionalTest extends \PHPUnit_Framework_TestCase
+class InvoiceFunctionalTest extends TestCase
 {
 
     public static $obj;

--- a/tests/PayPal/Test/Functional/Api/PaymentsFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/PaymentsFunctionalTest.php
@@ -6,13 +6,14 @@ use PayPal\Api\Payment;
 use PayPal\Api\Refund;
 use PayPal\Api\Sale;
 use PayPal\Test\Functional\Setup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebProfile
  *
  * @package PayPal\Test\Api
  */
-class PaymentsFunctionalTest extends \PHPUnit_Framework_TestCase
+class PaymentsFunctionalTest extends TestCase
 {
 
     public $operation;

--- a/tests/PayPal/Test/Functional/Api/PayoutsFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/PayoutsFunctionalTest.php
@@ -6,13 +6,14 @@ use PayPal\Api\Payout;
 use PayPal\Api\PayoutBatch;
 use PayPal\Api\PayoutItem;
 use PayPal\Test\Functional\Setup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Payouts
  *
  * @package PayPal\Test\Api
  */
-class PayoutsFunctionalTest extends \PHPUnit_Framework_TestCase
+class PayoutsFunctionalTest extends TestCase
 {
 
     public $operation;

--- a/tests/PayPal/Test/Functional/Api/WebProfileFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/WebProfileFunctionalTest.php
@@ -6,13 +6,14 @@ use PayPal\Api\CreateProfileResponse;
 use PayPal\Api\Patch;
 use PayPal\Api\WebProfile;
 use PayPal\Test\Functional\Setup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebProfile
  *
  * @package PayPal\Test\Api
  */
-class WebProfileFunctionalTest extends \PHPUnit_Framework_TestCase
+class WebProfileFunctionalTest extends TestCase
 {
 
     public $operation;

--- a/tests/PayPal/Test/Functional/Api/WebhookFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/WebhookFunctionalTest.php
@@ -11,13 +11,14 @@ use PayPal\Api\WebhookEventTypeList;
 use PayPal\Api\WebhookList;
 use PayPal\Exception\PayPalConnectionException;
 use PayPal\Test\Functional\Setup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class WebhookFunctionalTest
  *
  * @package PayPal\Test\Api
  */
-class WebhookFunctionalTest extends \PHPUnit_Framework_TestCase
+class WebhookFunctionalTest extends TestCase
 {
 
     public $operation;

--- a/tests/PayPal/Test/Functional/Setup.php
+++ b/tests/PayPal/Test/Functional/Setup.php
@@ -5,13 +5,14 @@ namespace PayPal\Test\Functional;
 use PayPal\Auth\OAuthTokenCredential;
 use PayPal\Core\PayPalCredentialManager;
 use PayPal\Rest\ApiContext;
+use PHPUnit\Framework\TestCase;
 
 class Setup
 {
 
     public static $mode = 'mock';
 
-    public static function SetUpForFunctionalTests(\PHPUnit_Framework_TestCase &$test)
+    public static function SetUpForFunctionalTests(TestCase &$test)
     {
         $configs = array(
             'mode' => 'sandbox',

--- a/tests/PayPal/Test/Handler/OauthHandlerTest.php
+++ b/tests/PayPal/Test/Handler/OauthHandlerTest.php
@@ -6,8 +6,9 @@ use PayPal\Auth\OAuthTokenCredential;
 use PayPal\Core\PayPalHttpConfig;
 use PayPal\Handler\OauthHandler;
 use PayPal\Rest\ApiContext;
+use PHPUnit\Framework\TestCase;
 
-class OauthHandlerTest extends \PHPUnit_Framework_TestCase
+class OauthHandlerTest extends TestCase
 {
 
     /**

--- a/tests/PayPal/Test/Rest/ApiContextTest.php
+++ b/tests/PayPal/Test/Rest/ApiContextTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use PayPal\Rest\ApiContext;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for ApiContextTest.
  *
  */
-class ApiContextTest extends PHPUnit_Framework_TestCase
+class ApiContextTest extends TestCase
 {
 
     /**

--- a/tests/PayPal/Test/Validation/ArgumentValidatorTest.php
+++ b/tests/PayPal/Test/Validation/ArgumentValidatorTest.php
@@ -2,8 +2,9 @@
 namespace PayPal\Test\Validation;
 
 use PayPal\Validation\ArgumentValidator;
+use PHPUnit\Framework\TestCase;
 
-class ArgumentValidatorTest extends \PHPUnit_Framework_TestCase
+class ArgumentValidatorTest extends TestCase
 {
 
     public static function positiveProvider()

--- a/tests/PayPal/Test/Validation/JsonValidatorTest.php
+++ b/tests/PayPal/Test/Validation/JsonValidatorTest.php
@@ -2,8 +2,9 @@
 namespace PayPal\Test\Validation;
 
 use PayPal\Validation\JsonValidator;
+use PHPUnit\Framework\TestCase;
 
-class JsonValidatorTest extends \PHPUnit_Framework_TestCase
+class JsonValidatorTest extends TestCase
 {
 
     public static function positiveProvider()

--- a/tests/PayPal/Test/Validation/NumericValidatorTest.php
+++ b/tests/PayPal/Test/Validation/NumericValidatorTest.php
@@ -2,8 +2,9 @@
 namespace PayPal\Test\Validation;
 
 use PayPal\Validation\NumericValidator;
+use PHPUnit\Framework\TestCase;
 
-class NumericValidatorTest extends \PHPUnit_Framework_TestCase
+class NumericValidatorTest extends TestCase
 {
 
     public static function positiveProvider()

--- a/tests/PayPal/Test/Validation/UrlValidatorTest.php
+++ b/tests/PayPal/Test/Validation/UrlValidatorTest.php
@@ -2,8 +2,9 @@
 namespace PayPal\Test\Validation;
 
 use PayPal\Validation\UrlValidator;
+use PHPUnit\Framework\TestCase;
 
-class UrlValidatorTest extends \PHPUnit_Framework_TestCase
+class UrlValidatorTest extends TestCase
 {
 
     public static function positiveProvider()


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.