### PR TITLE
Curl - Return the content of the request

### DIFF
--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -162,6 +162,9 @@ class PayPalHttpConnection
         $this->skippedHttpStatusLine = false;
         curl_setopt($ch, CURLOPT_HEADERFUNCTION, array($this, 'parseResponseHeaders'));
 
+        // return the contents of the transfer
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
         //Execute Curl Request
         $result = curl_exec($ch);
         //Retrieve Response Status


### PR DESCRIPTION
This PR fixes an issue with the usage of curl.
If run from a command line application, the curl response of any API call would get outputted on the console instead of being returned in a variable, to be used.

This behavior makes any call fail. The most common error is with getting an auth_token, like here:
https://github.com/paypal/PayPal-PHP-SDK/blob/master/lib/PayPal/Auth/OAuthTokenCredential.php#L273

If run from the command line, `$response` is by definition `true` since `CURLOPT_RETURNTRANSFER` is by default `false`