### PR TITLE
Use decimal separator of current environment

### DIFF
--- a/lib/PayPal/Converter/FormatConverter.php
+++ b/lib/PayPal/Converter/FormatConverter.php
@@ -48,12 +48,12 @@ class FormatConverter
         $decimals = 2;
         $currencyDecimals = array('JPY' => 0, 'TWD' => 0, 'HUF' => 0);
         if ($currency && array_key_exists($currency, $currencyDecimals)) {
-            if (strpos($value, ".") !== false && (floor($value) != $value)) {
+            if (strpos($value, localeconv()['decimal_point']) !== false && (floor($value) != $value)) {
                 //throw exception if it has decimal values for JPY, TWD and HUF which does not ends with .00
                 throw new \InvalidArgumentException("value cannot have decimals for $currency currency");
             }
             $decimals = $currencyDecimals[$currency];
-        } elseif (strpos($value, ".") === false) {
+        } elseif (strpos($value, localeconv()['decimal_point']) === false) {
             // Check if value has decimal values. If not no need to assign 2 decimals with .00 at the end
             $decimals = 0;
         }

--- a/lib/PayPal/Converter/FormatConverter.php
+++ b/lib/PayPal/Converter/FormatConverter.php
@@ -47,13 +47,14 @@ class FormatConverter
     {
         $decimals = 2;
         $currencyDecimals = array('JPY' => 0, 'TWD' => 0, 'HUF' => 0);
+        $formattingInformation = localeconv();
         if ($currency && array_key_exists($currency, $currencyDecimals)) {
-            if (strpos($value, localeconv()['decimal_point']) !== false && (floor($value) != $value)) {
+            if (strpos($value, $formattingInformation['decimal_point']) !== false && (floor($value) != $value)) {
                 //throw exception if it has decimal values for JPY, TWD and HUF which does not ends with .00
                 throw new \InvalidArgumentException("value cannot have decimals for $currency currency");
             }
             $decimals = $currencyDecimals[$currency];
-        } elseif (strpos($value, localeconv()['decimal_point']) === false) {
+        } elseif (strpos($value, $formattingInformation['decimal_point']) === false) {
             // Check if value has decimal values. If not no need to assign 2 decimals with .00 at the end
             $decimals = 0;
         }


### PR DESCRIPTION
Instead if forcing to use the . as the decimal separator use it from the locale information