### PR TITLE
Refactoring tests

### DIFF
--- a/tests/PayPal/Test/Api/CreditCardHistoryTest.php
+++ b/tests/PayPal/Test/Api/CreditCardHistoryTest.php
@@ -55,7 +55,7 @@ class CreditCardHistoryTest extends TestCase
         $cardHistory->setCreditCards(array($this->cards['partial'], $this->cards['full']));
         $cardHistory->setCount(2);
 
-        $this->assertEquals(2, count($cardHistory->getCreditCards()));
+        $this->assertCount(2, $cardHistory->getCreditCards());
     }
 
 

--- a/tests/PayPal/Test/Cache/AuthorizationCacheTest.php
+++ b/tests/PayPal/Test/Cache/AuthorizationCacheTest.php
@@ -95,7 +95,7 @@ class AuthorizationCacheTest extends TestCase
     {
         $result = AuthorizationCache::pull(array('cache.enabled' => true, 'cache.FileName' => AuthorizationCacheTest::CACHE_FILE), 'clientId');
         $this->assertNotNull($result);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertEquals('clientId', $result['clientId']);
         $this->assertEquals('accessToken', $result['accessTokenEncrypted']);
         $this->assertEquals('tokenCreateTime', $result['tokenCreateTime']);

--- a/tests/PayPal/Test/Common/ModelTest.php
+++ b/tests/PayPal/Test/Common/ModelTest.php
@@ -156,10 +156,10 @@ class ModelTest extends TestCase
         $obj->obj = '{}';
         $obj->objs = array('{}');
         $this->assertEquals("other", $obj->something);
-        $this->assertTrue(is_array($obj->else));
+        $this->assertInternalType('array', $obj->else);
         $this->assertNull($obj->there);
         $this->assertEquals('{}', $obj->obj);
-        $this->assertTrue(is_array($obj->objs));
+        $this->assertInternalType('array', $obj->objs);
         $this->assertEquals('{}', $obj->objs[0]);
     }
 

--- a/tests/PayPal/Test/Common/PayPalModelTest.php
+++ b/tests/PayPal/Test/Common/PayPalModelTest.php
@@ -280,7 +280,7 @@ class PayPalModelTest extends TestCase
     {
         $c1 = new SimpleModelTestClass();
         $c1->setField1("a")->setField2($field2);
-        $this->assertTrue(strpos($c1->toJSON(), "field2") !== !$matches);
+        $this->assertNotSame(strpos($c1->toJSON(), "field2"), !$matches);
     }
 
     public function getProvider()
@@ -332,8 +332,8 @@ class PayPalModelTest extends TestCase
         $this->assertEquals($expected, $result);
         if ($input) {
             $this->assertNotNull($result);
-            $this->assertTrue(is_array($result));
-            $this->assertEquals($count, sizeof($result));
+            $this->assertInternalType('array', $result);
+            $this->assertCount($count, $result);
         }
     }
 

--- a/tests/PayPal/Test/Core/PayPalCredentialManagerTest.php
+++ b/tests/PayPal/Test/Core/PayPalCredentialManagerTest.php
@@ -52,7 +52,7 @@ class PayPalCredentialManagerTest extends TestCase
     public function testGetInstance()
     {
         $instance = $this->object->getInstance($this->config);
-        $this->assertTrue($instance instanceof PayPalCredentialManager);
+        $this->assertInstanceOf('PayPal\Core\PayPalCredentialManager', $instance);
     }
 
     /**

--- a/tests/PayPal/Test/Core/PayPalHttpConfigTest.php
+++ b/tests/PayPal/Test/Core/PayPalHttpConfigTest.php
@@ -45,7 +45,7 @@ class PayPalHttpConfigTest extends TestCase
         $o->addHeader('key2', 'value');
         $o->addHeader('key2', 'overwritten');
 
-        $this->assertEquals(2, count($o->getHeaders()));
+        $this->assertCount(2, $o->getHeaders());
         $this->assertEquals('overwritten', $o->getHeader('key2'));
         $this->assertNull($o->getHeader('key3'));
 
@@ -54,11 +54,11 @@ class PayPalHttpConfigTest extends TestCase
         $o->addHeader('key2', 'value');
         $o->addHeader('key2', 'and more', false);
 
-        $this->assertEquals(2, count($o->getHeaders()));
+        $this->assertCount(2, $o->getHeaders());
         $this->assertEquals('value;and more', $o->getHeader('key2'));
 
         $o->removeHeader('key2');
-        $this->assertEquals(1, count($o->getHeaders()));
+        $this->assertCount(1, $o->getHeaders());
         $this->assertNull($o->getHeader('key2'));
     }
 
@@ -71,7 +71,7 @@ class PayPalHttpConfigTest extends TestCase
         $o->setCurlOptions(array('k' => 'v'));
 
         $curlOpts = $o->getCurlOptions();
-        $this->assertEquals(1, count($curlOpts));
+        $this->assertCount(1, $curlOpts);
         $this->assertEquals('v', $curlOpts['k']);
     }
 
@@ -80,12 +80,12 @@ class PayPalHttpConfigTest extends TestCase
         $o = new PayPalHttpConfig();
         $o->setCurlOptions(array('k' => 'v'));
         $curlOpts = $o->getCurlOptions();
-        $this->assertEquals(1, count($curlOpts));
+        $this->assertCount(1, $curlOpts);
         $this->assertEquals('v', $curlOpts['k']);
 
         $o->removeCurlOption('k');
         $curlOpts = $o->getCurlOptions();
-        $this->assertEquals(0, count($curlOpts));
+        $this->assertCount(0, $curlOpts);
     }
 
     /**

--- a/tests/PayPal/Test/Functional/Api/BillingAgreementsFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/BillingAgreementsFunctionalTest.php
@@ -175,8 +175,8 @@ class BillingAgreementsFunctionalTest extends TestCase
         $params = array('start_date' => date('Y-m-d', strtotime('-15 years')), 'end_date' => date('Y-m-d', strtotime('+5 days')));
         $result = Agreement::searchTransactions($agreement->getId(), $params, $this->apiContext, $this->mockPayPalRestCall);
         $this->assertNotNull($result);
-        $this->assertTrue(is_array($result->getAgreementTransactionList()));
-        $this->assertTrue(sizeof($result->getAgreementTransactionList()) > 0);
+        $this->assertInternalType('array', $result->getAgreementTransactionList());
+        $this->assertGreaterThan(0, sizeof($result->getAgreementTransactionList()));
         $list = $result->getAgreementTransactionList();
         $first = $list[0];
         $this->assertEquals($first->getTransactionId(), $agreement->getId());

--- a/tests/PayPal/Test/Functional/Api/PayoutsFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/PayoutsFunctionalTest.php
@@ -63,7 +63,7 @@ class PayoutsFunctionalTest extends TestCase
         $this->assertEquals(PayoutsFunctionalTest::$batchId, $result->getBatchHeader()->getSenderBatchHeader()->getSenderBatchId());
         $this->assertEquals('SUCCESS', $result->getBatchHeader()->getBatchStatus());
         $items = $result->getItems();
-        $this->assertTrue(sizeof($items) > 0);
+        $this->assertGreaterThan(0, sizeof($items));
         $item = $items[0];
         $this->assertEquals('UNCLAIMED', $item->getTransactionStatus());
         return $result;

--- a/tests/PayPal/Test/Functional/Api/WebhookFunctionalTest.php
+++ b/tests/PayPal/Test/Functional/Api/WebhookFunctionalTest.php
@@ -103,7 +103,7 @@ class WebhookFunctionalTest extends TestCase
     {
         $result = WebhookEventType::subscribedEventTypes($webhook->getId(), $this->apiContext, $this->mockPayPalRestCall);
         $this->assertNotNull($result);
-        $this->assertEquals(2, sizeof($result->getEventTypes()));
+        $this->assertCount(2, $result->getEventTypes());
         return $result;
     }
 


### PR DESCRIPTION
I've refactored some tests, using:
- `assertInternalType` instead of `is_*` functions;
- `assertCount` instead of `count` and `sizeof` functions;
- `assertNotSame` instead os strict comparisons `!==`;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertGreaterThan` for mathematical comparisons.