### PR TITLE
Re-Order the array keys so that JSON will be an array, not an object

### DIFF
--- a/lib/PayPal/Api/CartBase.php
+++ b/lib/PayPal/Api/CartBase.php
@@ -290,7 +290,7 @@ class CartBase extends PayPalModel
      */
     public function setItemList($item_list)
     {
-        $this->item_list = $item_list;
+        $this->item_list = array_values($item_list);
         return $this;
     }
 

--- a/lib/PayPal/Api/CartBase.php
+++ b/lib/PayPal/Api/CartBase.php
@@ -290,7 +290,7 @@ class CartBase extends PayPalModel
      */
     public function setItemList($item_list)
     {
-        $this->item_list = array_values($item_list);
+        $this->item_list = $item_list;
         return $this;
     }
 

--- a/lib/PayPal/Api/ItemList.php
+++ b/lib/PayPal/Api/ItemList.php
@@ -27,7 +27,7 @@ class ItemList extends PayPalModel
      */
     public function setItems($items)
     {
-        $this->items = $items;
+        $this->items = array_values($items);
         return $this;
     }
 

--- a/tests/PayPal/Test/Api/ItemListTest.php
+++ b/tests/PayPal/Test/Api/ItemListTest.php
@@ -53,7 +53,7 @@ class ItemListTest extends TestCase
      */
     public function testGetters($obj)
     {
-        $this->assertEquals($obj->getItems(), ItemTest::getObject());
+        $this->assertEquals($obj->getItems(), [ItemTest::getObject()]);
         $this->assertEquals($obj->getShippingAddress(), ShippingAddressTest::getObject());
         $this->assertEquals($obj->getShippingMethod(), "TestSample");
         $this->assertEquals($obj->getShippingPhoneNumber(), "TestSample");

--- a/tests/PayPal/Test/Api/ItemListTest.php
+++ b/tests/PayPal/Test/Api/ItemListTest.php
@@ -18,7 +18,7 @@ class ItemListTest extends TestCase
      */
     public static function getJson()
     {
-        return '{"items":' . ItemTest::getJson() . ',"shipping_address":' . ShippingAddressTest::getJson() . ',"shipping_method":"TestSample","shipping_phone_number":"TestSample"}';
+        return '{"items":[' . ItemTest::getJson() . '],"shipping_address":' . ShippingAddressTest::getJson() . ',"shipping_method":"TestSample","shipping_phone_number":"TestSample"}';
     }
 
     /**

--- a/tests/PayPal/Test/Api/ItemListTest.php
+++ b/tests/PayPal/Test/Api/ItemListTest.php
@@ -2,6 +2,7 @@
 
 namespace PayPal\Test\Api;
 
+use PayPal\Api\Item;
 use PayPal\Api\ItemList;
 use PHPUnit\Framework\TestCase;
 
@@ -57,5 +58,24 @@ class ItemListTest extends TestCase
         $this->assertEquals($obj->getShippingAddress(), ShippingAddressTest::getObject());
         $this->assertEquals($obj->getShippingMethod(), "TestSample");
         $this->assertEquals($obj->getShippingPhoneNumber(), "TestSample");
+    }
+	
+	/**
+     * @depends testSerializationDeserialization
+     * @param ItemList $obj
+     */
+    public function testAddRemove($obj)
+    {
+		$item2 = new Item(ItemTest::getJSON());
+		$item2->setSku('TestSample2');
+        $item3 = new Item(ItemTest::getJSON());
+		$item3->setSku('TestSample3');
+		$obj->addItem($item2);
+		$obj->addItem($item3);
+		$this->assertCount(3, $obj->getItems());
+		$obj->removeItem($item2);
+		
+		$this->assertCount(2, $obj->getItems());
+		$this->assertContains('"items":[', $obj->toJSON());
     }
 }

--- a/tests/PayPal/Test/Api/ItemListTest.php
+++ b/tests/PayPal/Test/Api/ItemListTest.php
@@ -53,7 +53,7 @@ class ItemListTest extends TestCase
      */
     public function testGetters($obj)
     {
-        $this->assertEquals($obj->getItems(), [ItemTest::getObject()]);
+        $this->assertEquals($obj->getItems(), array(ItemTest::getObject()));
         $this->assertEquals($obj->getShippingAddress(), ShippingAddressTest::getObject());
         $this->assertEquals($obj->getShippingMethod(), "TestSample");
         $this->assertEquals($obj->getShippingPhoneNumber(), "TestSample");


### PR DESCRIPTION
SDK/Library version: 1.13.0
Environment: Sandbox
PayPal-Debug-ID values: 3a5fd0a7adf56

I have create an Item array along these lines:
```php
$items = [ null, new Item() ];
$items = array_filter($items, function($value) { return !is_null($value); })
$itemList->setItems($items);
```

Which returns this error from the API:
```json
{"name":"MALFORMED_REQUEST","message":"Incoming JSON request does not map to API request" }
```

Here is the generated JSON:
```
{
   "intent":"sale",
   "payer":{
      "payment_method":"paypal"
   },
   "redirect_urls":{
      "return_url":"http://local/?id=67&type=4835&mail_id=8190&success=true",
      "cancel_url":"http://local/?id=67&type=4835&mail_id=8190&success=false"
   },
   "transactions":[
      {
         "amount":{
            "currency":"EUR",
            "total":"400"
         },
         "item_list":{
            "items":{
               "1":{
                  "name":"Label",
                  "currency":"EUR",
                  "price":"400",
                  "quantity":1
               }
            }
         },
         "description":"Ich m\u00f6chte spenden",
         "invoice_number":8190
      }
   ],
   "note_to_payer":"Ich m\u00f6chte spenden",
   "experience_profile_id":"XP-ZZZZ-FPCC-ZCSS-YUZD"
}
```

Not that "items" is not an array here, but an object - the only difference to working requests. 

As the SDK only requires to submit an array, not an "array numbered from 0..N" (e.g. it also could be an associative array), I suggest using `array_values` as in this pull request. Probably this should be added at other places of the API as well for consistency.

This kind of error could also appear when using "ItemList->removeItem", as array_diff also doesn't re-order the keys (see unit test).

The Unit test failed at the beginning because setItems is given `Item` instead of `array(Item)`, is this a legacy/compability usage?