### PR TITLE
Add SimulateEvent model

### DIFF
--- a/lib/PayPal/Api/SimulateEvent.php
+++ b/lib/PayPal/Api/SimulateEvent.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace PayPal\Api;
+
+use PayPal\Common\PayPalResourceModel;
+use PayPal\Validation\UrlValidator;
+
+/**
+ * Class SimulateEvent
+ *
+ * Use a sample payload to simulate a webhook event.
+ *
+ * @package PayPal\Api
+ *
+ * @property string webhook_id
+ * @property string url
+ * @property string event_type
+ */
+class SimulateEvent extends PayPalResourceModel
+{
+    /**
+     * The ID of the webhook as configured in your Developer Portal account.
+     *
+     * @param string $webhook_id
+     *
+     * @return $this
+     */
+    public function setWebhookId($webhook_id)
+    {
+        $this->webhook_id = $webhook_id;
+        return $this;
+    }
+
+    /**
+     * The ID of the webhook as configured in your Developer Portal account.
+     *
+     * @return string
+     */
+    public function getWebhookId()
+    {
+        return $this->webhook_id;
+    }
+
+    /**
+     * The URL that is configured to listen on `localhost` for incoming `POST` notification messages that contain event information.
+     *
+     * @param string $url
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function setUrl($url)
+    {
+        UrlValidator::validate($url, "Url");
+        $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * The URL that is configured to listen on `localhost` for incoming `POST` notification messages that contain event information.
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * The event that triggered the webhook event notification.
+     *
+     * @param string $event_type
+     *
+     * @return $this
+     */
+    public function setEventType($event_type)
+    {
+        $this->event_type = $event_type;
+        return $this;
+    }
+
+    /**
+     * The event that triggered the webhook event notification.
+     *
+     * @return string
+     */
+    public function getEventType()
+    {
+        return $this->event_type;
+    }
+
+    /**
+     * Simulates a webhook event. A successful call returns a mock [`event`](/docs/api/webhooks/#definition-event) object.
+     *
+     * @param \PayPal\Rest\ApiContext $apiContext is the APIContext for this call. It can be used to pass dynamic configuration and credentials.
+     * @param \PayPal\Transport\PayPalRestCall $restCall is the Rest Call Service that is used to make rest calls
+     * @return WebhookEvent
+     */
+    public function create($apiContext = null, $restCall = null)
+    {
+        $payLoad = $this->toJSON();
+        $json = self::executeCall(
+            "/v1/notifications/simulate-event",
+            "POST",
+            $payLoad,
+            null,
+            $apiContext,
+            $restCall
+        );
+        $ret = new WebhookEvent();
+        $ret->fromJson($json);
+        return $ret;
+    }
+}

--- a/tests/PayPal/Test/Api/SimulateEventTest.php
+++ b/tests/PayPal/Test/Api/SimulateEventTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PayPal\Test\Api;
+
+use PayPal\Api\SimulateEvent;
+use PayPal\Rest\ApiContext;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SimulatesEvent
+ *
+ * @package PayPal\Test\Api
+ */
+class SimulatesEventTest extends TestCase
+{
+    /**
+     * Gets Json String of Object SimulateEvent
+     * @return string
+     */
+    public static function getJson()
+    {
+        return '{"webhook_id":"TestSample","url":"http://www.google.com","event_type":"TestSample"}';
+    }
+
+    /**
+     * Gets Object Instance with Json data filled in
+     * @return SimulateEvent
+     */
+    public static function getObject()
+    {
+        return new SimulateEvent(self::getJson());
+    }
+
+    /**
+     * Tests for Serialization and Deserialization Issues
+     * @return SimulateEvent
+     */
+    public function testSerializationDeserialization()
+    {
+        $obj = new SimulateEvent(self::getJson());
+        $this->assertNotNull($obj);
+        $this->assertNotNull($obj->getWebhookId());
+        $this->assertNotNull($obj->getUrl());
+        $this->assertNotNull($obj->getEventType());
+        $this->assertEquals(self::getJson(), $obj->toJson());
+        return $obj;
+    }
+
+    /**
+     * @depends testSerializationDeserialization
+     * @param SimulateEvent $obj
+     */
+    public function testGetters($obj)
+    {
+        $this->assertEquals($obj->getWebhookId(), "TestSample");
+        $this->assertEquals($obj->getUrl(), "http://www.google.com");
+        $this->assertEquals($obj->getEventType(), "TestSample");
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Url is not a fully qualified URL
+     */
+    public function testUrlValidationForUrl()
+    {
+        $obj = new SimulateEvent();
+        $obj->setUrl(null);
+    }
+
+    /**
+     * @dataProvider mockProvider
+     * @param SimulateEvent $obj
+     * @param ApiContext|null $mockApiContext
+     */
+    public function testCreate($obj, $mockApiContext)
+    {
+        $mockPPRestCall = $this->getMockBuilder('\PayPal\Transport\PayPalRestCall')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockPPRestCall->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue(
+                self::getJson()
+            ));
+
+        $result = $obj->create($mockApiContext, $mockPPRestCall);
+        $this->assertNotNull($result);
+    }
+
+    public function mockProvider()
+    {
+        $obj = self::getObject();
+        $mockApiContext = $this->getMockBuilder('ApiContext')
+            ->disableOriginalConstructor()
+            ->getMock();
+        return array(
+            array($obj, $mockApiContext),
+            array($obj, null)
+        );
+    }
+}


### PR DESCRIPTION
https://developer.paypal.com/docs/api/webhooks/#simulate-event

```php
$event = (new SimulateEvent([
    'webhook_id' => $webhookId,
    'event_type' => 'PAYMENT.CAPTURE.REFUNDED',
]))->create($apiContext);
```

or

```php
$event = (new SimulateEvent([
    'url' => 'https://dev.my-project.com/api/paypal-webhook',
    'event_type' => 'PAYMENT.CAPTURE.REFUNDED',
]))->create($apiContext);
```