### PR TITLE
Enforce the use of tls 1.2 for the PayPalHttpConnection.

### DIFF
--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -145,6 +145,9 @@ class PayPalHttpConnection
         curl_setopt($ch, CURLINFO_HEADER_OUT, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getHttpHeaders());
 
+        // Some environments may be capable of TLS 1.2 but it is not in their list of defaults so need the SSL version option to be set.
+        curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+
         //Determine Curl Options based on Method
         switch ($this->httpConfig->getMethod()) {
             case 'POST':

--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -146,7 +146,7 @@ class PayPalHttpConnection
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getHttpHeaders());
 
         // Some environments may be capable of TLS 1.2 but it is not in their list of defaults so need the SSL version option to be set.
-        curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+        curl_setopt($ch, CURLOPT_SSLVERSION, defined(CURL_SSLVERSION_TLSv1_2) ? CURL_SSLVERSION_TLSv1_2 : 6);
 
         //Determine Curl Options based on Method
         switch ($this->httpConfig->getMethod()) {

--- a/lib/PayPal/Core/PayPalHttpConnection.php
+++ b/lib/PayPal/Core/PayPalHttpConnection.php
@@ -146,7 +146,7 @@ class PayPalHttpConnection
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getHttpHeaders());
 
         // Some environments may be capable of TLS 1.2 but it is not in their list of defaults so need the SSL version option to be set.
-        curl_setopt($ch, CURLOPT_SSLVERSION, defined(CURL_SSLVERSION_TLSv1_2) ? CURL_SSLVERSION_TLSv1_2 : 6);
+        curl_setopt($ch, CURLOPT_SSLVERSION, 6);
 
         //Determine Curl Options based on Method
         switch ($this->httpConfig->getMethod()) {


### PR DESCRIPTION
We have still received the notification that we needed to upgrade to use the TLS 1.2.
Our server supports TLS1.2 so it's probably related to curl not being forced to use the TLS1.2.

This snippet has been taken from the test php file that was provided by PayPal itself.
See https://github.com/paypal/TLS-update/blob/master/php/TlsCheck.php

Kind regards,
Ward