### PR TITLE
Added note_to_payer property to Capture class

### DIFF
--- a/lib/PayPal/Api/Capture.php
+++ b/lib/PayPal/Api/Capture.php
@@ -215,6 +215,29 @@ class Capture extends PayPalResourceModel
     }
 
     /**
+     * A free-form field that clients can use to send a note to the payer.
+     *
+     * @param string $note_to_payer
+     *
+     * @return $this
+     */
+    public function setNoteToPayer($note_to_payer)
+    {
+        $this->note_to_payer = $note_to_payer;
+        return $this;
+    }
+
+    /**
+     * A free-form field that clients can use to send a note to the payer.
+     *
+     * @return string
+     */
+    public function getNoteToPayer()
+    {
+        return $this->note_to_payer;
+    }
+
+    /**
      * The date and time of capture, as defined in [RFC 3339 Section 5.6](http://tools.ietf.org/html/rfc3339#section-5.6).
      *
      * @param string $create_time

--- a/tests/PayPal/Test/Api/CaptureTest.php
+++ b/tests/PayPal/Test/Api/CaptureTest.php
@@ -19,7 +19,7 @@ class CaptureTest extends TestCase
      */
     public static function getJson()
     {
-        return '{"id":"TestSample","amount":' .AmountTest::getJson() . ',"is_final_capture":true,"state":"TestSample","reason_code":"TestSample","parent_payment":"TestSample","invoice_number":"TestSample","transaction_fee":' .CurrencyTest::getJson() . ',"create_time":"TestSample","update_time":"TestSample","links":' .LinksTest::getJson() . '}';
+        return '{"id":"TestSample","amount":' .AmountTest::getJson() . ',"is_final_capture":true,"state":"TestSample","reason_code":"TestSample","parent_payment":"TestSample","invoice_number":"TestSample","transaction_fee":' .CurrencyTest::getJson() . ',"note_to_payer":"TestSample","create_time":"TestSample","update_time":"TestSample","links":' .LinksTest::getJson() . '}';
     }
 
     /**
@@ -48,6 +48,7 @@ class CaptureTest extends TestCase
         $this->assertNotNull($obj->getParentPayment());
         $this->assertNotNull($obj->getInvoiceNumber());
         $this->assertNotNull($obj->getTransactionFee());
+        $this->assertNotNull($obj->getNoteToPayer());
         $this->assertNotNull($obj->getCreateTime());
         $this->assertNotNull($obj->getUpdateTime());
         $this->assertNotNull($obj->getLinks());
@@ -69,6 +70,7 @@ class CaptureTest extends TestCase
         $this->assertEquals($obj->getParentPayment(), "TestSample");
         $this->assertEquals($obj->getInvoiceNumber(), "TestSample");
         $this->assertEquals($obj->getTransactionFee(), CurrencyTest::getObject());
+        $this->assertEquals($obj->getNoteToPayer(), "TestSample");
         $this->assertEquals($obj->getCreateTime(), "TestSample");
         $this->assertEquals($obj->getUpdateTime(), "TestSample");
         $this->assertEquals($obj->getLinks(), LinksTest::getObject());


### PR DESCRIPTION
According to official capture docs Paypal's capture method https://developer.paypal.com/docs/api/payments/v1/#capture accepts a free-form-field called note_to_payer to send a note to the payer.