### PR TITLE
NotifyUrl, CancelUrl and/or ReturnUrl can be null in PayPal response

### DIFF
--- a/lib/PayPal/Api/MerchantPreferences.php
+++ b/lib/PayPal/Api/MerchantPreferences.php
@@ -80,7 +80,7 @@ class MerchantPreferences extends PayPalModel
      */
     public function setCancelUrl($cancel_url)
     {
-        if ($this->cancel_url !== null) {
+        if ($cancel_url !== null) {
             UrlValidator::validate($cancel_url, "CancelUrl");
         }
         $this->cancel_url = $cancel_url;
@@ -106,7 +106,7 @@ class MerchantPreferences extends PayPalModel
      */
     public function setReturnUrl($return_url)
     {
-        if ($this->return_url !== null) {
+        if ($return_url!== null) {
             UrlValidator::validate($return_url, "ReturnUrl");
         }
         $this->return_url = $return_url;
@@ -132,7 +132,7 @@ class MerchantPreferences extends PayPalModel
      */
     public function setNotifyUrl($notify_url)
     {
-        if ($this->notify_url !== null) {
+        if ($notify_url !== null) {
             UrlValidator::validate($notify_url, "NotifyUrl");
         }
         $this->notify_url = $notify_url;

--- a/lib/PayPal/Api/MerchantPreferences.php
+++ b/lib/PayPal/Api/MerchantPreferences.php
@@ -80,7 +80,9 @@ class MerchantPreferences extends PayPalModel
      */
     public function setCancelUrl($cancel_url)
     {
-        UrlValidator::validate($cancel_url, "CancelUrl");
+        if ($this->cancel_url !== null) {
+            UrlValidator::validate($cancel_url, "CancelUrl");
+        }
         $this->cancel_url = $cancel_url;
         return $this;
     }

--- a/lib/PayPal/Api/MerchantPreferences.php
+++ b/lib/PayPal/Api/MerchantPreferences.php
@@ -104,7 +104,9 @@ class MerchantPreferences extends PayPalModel
      */
     public function setReturnUrl($return_url)
     {
-        UrlValidator::validate($return_url, "ReturnUrl");
+        if ($this->return_url !== null) {
+            UrlValidator::validate($return_url, "ReturnUrl");
+        }
         $this->return_url = $return_url;
         return $this;
     }
@@ -129,8 +131,8 @@ class MerchantPreferences extends PayPalModel
     public function setNotifyUrl($notify_url)
     {
         if ($this->notify_url !== null) {
-    	    UrlValidator::validate($notify_url, "NotifyUrl");
-    	}
+            UrlValidator::validate($notify_url, "NotifyUrl");
+        }
         $this->notify_url = $notify_url;
         return $this;
     }

--- a/lib/PayPal/Api/MerchantPreferences.php
+++ b/lib/PayPal/Api/MerchantPreferences.php
@@ -128,7 +128,9 @@ class MerchantPreferences extends PayPalModel
      */
     public function setNotifyUrl($notify_url)
     {
-        UrlValidator::validate($notify_url, "NotifyUrl");
+        if ($this->notify_url !== null) {
+    	    UrlValidator::validate($notify_url, "NotifyUrl");
+    	}
         $this->notify_url = $notify_url;
         return $this;
     }


### PR DESCRIPTION
Due to a change in the PayPal response NotifyUrl, CancelUrl and/or ReturnUrl can be null, which in turn caused an exception.