### PR TITLE
Fix for "InvalidArgumentException" thrown by PayPal\Validation\UrlValidator when NotifyUrl is NULL from Response

### DIFF
--- a/lib/PayPal/Api/MerchantPreferences.php
+++ b/lib/PayPal/Api/MerchantPreferences.php
@@ -80,7 +80,9 @@ class MerchantPreferences extends PayPalModel
      */
     public function setCancelUrl($cancel_url)
     {
-        UrlValidator::validate($cancel_url, "CancelUrl");
+        if (!is_null($cancel_url)) {
+            UrlValidator::validate($cancel_url, "CancelUrl");
+        }
         $this->cancel_url = $cancel_url;
         return $this;
     }
@@ -104,7 +106,9 @@ class MerchantPreferences extends PayPalModel
      */
     public function setReturnUrl($return_url)
     {
-        UrlValidator::validate($return_url, "ReturnUrl");
+        if (!is_null($return_url)) {
+            UrlValidator::validate($return_url, "ReturnUrl");
+        }
         $this->return_url = $return_url;
         return $this;
     }
@@ -128,7 +132,9 @@ class MerchantPreferences extends PayPalModel
      */
     public function setNotifyUrl($notify_url)
     {
-        UrlValidator::validate($notify_url, "NotifyUrl");
+        if (!is_null($notify_url)) {
+            UrlValidator::validate($notify_url, "NotifyUrl");
+        }
         $this->notify_url = $notify_url;
         return $this;
     }


### PR DESCRIPTION
Fix for "InvalidArgumentException" thrown by PayPal\Validation\UrlValidator when NotifyUrl is NULL from Response

This only started recently for some reason.