### PR TITLE
Integration with paypal Sync API

### DIFF
--- a/lib/PayPal/Api/Amount.php
+++ b/lib/PayPal/Api/Amount.php
@@ -23,7 +23,7 @@ class Amount extends PayPalModel
      * 3-letter [currency code](https://developer.paypal.com/docs/integration/direct/rest_api_payment_country_currency_support/). PayPal does not support all currencies.
      *
      * @param string $currency
-     * 
+     *
      * @return $this
      */
     public function setCurrency($currency)
@@ -46,7 +46,7 @@ class Amount extends PayPalModel
      * Total amount charged from the payer to the payee. In case of a refund, this is the refunded amount to the original payer from the payee. 10 characters max with support for 2 decimal places.
      *
      * @param string|double $total
-     * 
+     *
      * @return $this
      */
     public function setTotal($total)
@@ -68,35 +68,10 @@ class Amount extends PayPalModel
     }
 
     /**
-     * Set amount value. Format it using currency converter.
-     *
-     * @param string|double $value
-     *
-     * @return $this
-     */
-    public function setValue($value)
-    {
-        NumericValidator::validate($value, "Total");
-        $value = FormatConverter::formatToPrice($value, $this->getCurrency());
-        $this->value = $value;
-        return $this;
-    }
-
-    /**
-     * Get amount value.
-     *
-     * @return string
-     */
-    public function getValue()
-    {
-        return $this->value;
-    }
-
-    /**
      * Additional details of the payment amount.
      *
      * @param \PayPal\Api\Details $details
-     * 
+     *
      * @return $this
      */
     public function setDetails($details)

--- a/lib/PayPal/Api/Amount.php
+++ b/lib/PayPal/Api/Amount.php
@@ -68,6 +68,31 @@ class Amount extends PayPalModel
     }
 
     /**
+     * Set amount value. Format it using currency converter.
+     *
+     * @param string|double $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        NumericValidator::validate($value, "Total");
+        $value = FormatConverter::formatToPrice($value, $this->getCurrency());
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * Get amount value.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
      * Additional details of the payment amount.
      *
      * @param \PayPal\Api\Details $details

--- a/lib/PayPal/Api/ReportingTransactionAmount.php
+++ b/lib/PayPal/Api/ReportingTransactionAmount.php
@@ -65,5 +65,4 @@ class ReportingTransactionAmount extends PayPalModel
     {
         return $this->value;
     }
-
 }

--- a/lib/PayPal/Api/ReportingTransactionAmount.php
+++ b/lib/PayPal/Api/ReportingTransactionAmount.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace PayPal\Api;
+
+use PayPal\Common\PayPalModel;
+use PayPal\Converter\FormatConverter;
+use PayPal\Validation\NumericValidator;
+
+/**
+ * Class ReportingTransactionAmount
+ *
+ * payment amount model used by reporting transactions.
+ *
+ * @package PayPal\Api
+ *
+ * @property string currency_code
+ * @property string value
+ */
+class ReportingTransactionAmount extends PayPalModel
+{
+    /**
+     * 3-letter [currency code](https://developer.paypal.com/docs/integration/direct/rest_api_payment_country_currency_support/). PayPal does not support all currencies.
+     *
+     * @param string $currency_code
+     *
+     * @return $this
+     */
+    public function setCurrencyCode($currency_code)
+    {
+        $this->currencyCode = $currency_code;
+        return $this;
+    }
+
+    /**
+     * 3-letter [currency code](https://developer.paypal.com/docs/integration/direct/rest_api_payment_country_currency_support/). PayPal does not support all currencies.
+     *
+     * @return string
+     */
+    public function getCurrencyCode()
+    {
+        return $this->currencyCode;
+    }
+
+    /**
+     * Set amount value. Format it using currency converter.
+     *
+     * @param string|double $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        NumericValidator::validate($value, "Total");
+        $value = FormatConverter::formatToPrice($value, $this->getCurrencyCode());
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * Get amount value.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+}

--- a/lib/PayPal/Api/ReportingTransactionDetails.php
+++ b/lib/PayPal/Api/ReportingTransactionDetails.php
@@ -3,7 +3,6 @@
 
 namespace PayPal\Api;
 
-
 use PayPal\Common\PayPalModel;
 
 /**
@@ -35,5 +34,4 @@ class ReportingTransactionDetails extends PayPalModel
     {
         $this->transactionInfo = $transactionInfo;
     }
-
 }

--- a/lib/PayPal/Api/ReportingTransactionDetails.php
+++ b/lib/PayPal/Api/ReportingTransactionDetails.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace PayPal\Api;
+
+
+use PayPal\Common\PayPalModel;
+
+/**
+ * Class ReportingTransactionInfo.
+ *
+ * Model for transaction details.
+ *
+ * @package PayPal\Api
+ *
+ * @property \PayPal\Api\ReportingTransactionInfo transaction_info
+ */
+class ReportingTransactionDetails extends PayPalModel
+{
+    protected $transactionInfo;
+    // @TODO: build rest of fields!
+
+    /**
+     * @return \PayPal\Api\ReportingTransactionInfo
+     */
+    public function getTransactionInfo()
+    {
+        return $this->transactionInfo;
+    }
+
+    /**
+     * @param \PayPal\Api\ReportingTransactionInfo $transactionInfo
+     */
+    public function setTransactionInfo($transactionInfo)
+    {
+        $this->transactionInfo = $transactionInfo;
+    }
+
+}

--- a/lib/PayPal/Api/ReportingTransactionInfo.php
+++ b/lib/PayPal/Api/ReportingTransactionInfo.php
@@ -241,7 +241,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The invoice ID that is sent by the merchant with the transaction.
      *
-     * @param mixed $invoiceId
+     * @param string $invoiceId
      */
     public function setInvoiceId($invoiceId)
     {

--- a/lib/PayPal/Api/ReportingTransactionInfo.php
+++ b/lib/PayPal/Api/ReportingTransactionInfo.php
@@ -1,0 +1,271 @@
+<?php
+
+
+namespace PayPal\Api;
+
+
+use PayPal\Common\PayPalModel;
+
+/**
+ * Class ReportingTransactionInfo
+ *
+ * Model for transaction info.
+ *
+ * @package PayPal\Api
+ *
+ * @property string paypal_account_id
+ * @property string transaction_id
+ * @property string transaction_event_code
+ * @property string transaction_initiation_date
+ * @property string transaction_updated_date
+ * @property \PayPal\Api\Amount transaction_amount
+ * @property \PayPal\Api\Amount fee_amount
+ * @property \PayPal\Api\Amount ending_balance
+ * @property \PayPal\Api\Amount available_balance
+ * @property \PayPal\Api\Amount invoice_id
+ * @property \PayPal\Api\Amount protection_elegibility
+ */
+class ReportingTransactionInfo extends PayPalModel
+{
+
+    /**
+     * The ID of the PayPal account of the counterparty.
+     *
+     * @return string
+     */
+    public function getPaypalAccountId()
+    {
+        return $this->paypalAccountId;
+    }
+
+    /**
+     * The ID of the PayPal account of the counterparty.
+     *
+     * @param string $paypalAccountId
+     */
+    public function setPaypalAccountId($paypalAccountId)
+    {
+        $this->paypalAccountId = $paypalAccountId;
+    }
+
+    /**
+     * The PayPal-generated transaction ID.
+     *
+     * @return string
+     */
+    public function getTransactionId()
+    {
+        return $this->transactionId;
+    }
+
+    /**
+     * The PayPal-generated transaction ID.
+     *
+     * @param string $transactionId
+     */
+    public function setTransactionId($transactionId)
+    {
+        $this->transactionId = $transactionId;
+    }
+
+    /**
+     * A five-digit transaction event code that classifies the transaction type based on money movement and debit or credit. For example, T0001. See Transaction event codes.
+     *
+     * @return string
+     */
+    public function getTransactionEventCode()
+    {
+        return $this->transactionEventCode;
+    }
+
+    /**
+     * A five-digit transaction event code that classifies the transaction type based on money movement and debit or credit. For example, T0001. See Transaction event codes.
+     *
+     * @param string $transactionEventCode
+     */
+    public function setTransactionEventCode($transactionEventCode)
+    {
+        $this->transactionEventCode = $transactionEventCode;
+    }
+
+    /**
+     * The date and time when work on a transaction began in the PayPal system, as expressed in the time zone of the account on this side of the payment. Specify the value in Internet date and time format.
+     *
+     * @return string
+     */
+    public function getTransactionInitiationDate()
+    {
+        return $this->transactionInitiationDate;
+    }
+
+    /**
+     * The date and time when work on a transaction began in the PayPal system, as expressed in the time zone of the account on this side of the payment. Specify the value in Internet date and time format.
+     *
+     * @param string $transactionInitiationDate
+     */
+    public function setTransactionInitiationDate($transactionInitiationDate)
+    {
+        $this->transactionInitiationDate = $transactionInitiationDate;
+    }
+
+    /**
+     * The date and time when the transaction was last changed, as expressed in the time zone of the account on this side of the payment. Specify the value in Internet date and time format.
+     *
+     * @return string
+     */
+    public function getTransactionUpdatedDate()
+    {
+        return $this->transactionUpdatedDate;
+    }
+
+    /**
+     * The date and time when the transaction was last changed, as expressed in the time zone of the account on this side of the payment. Specify the value in Internet date and time format.
+     *
+     * @param string $transactionUpdatedDate
+     */
+    public function setTransactionUpdatedDate($transactionUpdatedDate)
+    {
+        $this->transactionUpdatedDate = $transactionUpdatedDate;
+    }
+
+    /**
+     * The all-inclusive gross transaction amount that was transferred between the sender and receiver through PayPal.
+     *
+     * @return \PayPal\Api\Amount
+     */
+    public function getTransactionAmount()
+    {
+        return $this->transactionAmount;
+    }
+
+    /**
+     * The all-inclusive gross transaction amount that was transferred between the sender and receiver through PayPal.
+     *
+     * @param \PayPal\Api\Amount $transactionAmount
+     */
+    public function setTransactionAmount($transactionAmount)
+    {
+        $this->transactionAmount = $transactionAmount;
+    }
+
+    /**
+     * The PayPal fee amount. All transaction fees are included in this amount, which is the record of fee associated with the transaction.
+     *
+     * @return \PayPal\Api\Amount
+     */
+    public function getFeeAmount()
+    {
+        return $this->feeAmount;
+    }
+
+    /**
+     * The PayPal fee amount. All transaction fees are included in this amount, which is the record of fee associated with the transaction.
+     *
+     * @param \PayPal\Api\Amount $feeAmount
+     */
+    public function setFeeAmount($feeAmount)
+    {
+        $this->feeAmount = $feeAmount;
+    }
+
+    /**
+     * Filters the transactions in the response by a PayPal transaction status code.
+     *
+     * @return string
+     */
+    public function getTransactionStatus()
+    {
+        return $this->transactionStatus;
+    }
+
+    /**
+     * Filters the transactions in the response by a PayPal transaction status code.
+     *
+     * @param string $transactionStatus
+     */
+    public function setTransactionStatus($transactionStatus)
+    {
+        $this->transactionStatus = $transactionStatus;
+    }
+
+    /**
+     * The ending balance.
+     *
+     * @return \PayPal\Api\Amount
+     */
+    public function getEndingBalance()
+    {
+        return $this->endingBalance;
+    }
+
+    /**
+     * The ending balance.
+     *
+     * @param \PayPal\Api\Amount $endingBalance
+     */
+    public function setEndingBalance($endingBalance)
+    {
+        $this->endingBalance = $endingBalance;
+    }
+
+    /**
+     * The available amount of transaction currency during the completion of this transaction.
+     *
+     * @return \PayPal\Api\Amount
+     */
+    public function getAvailableBalance()
+    {
+        return $this->availableBalance;
+    }
+
+    /**
+     * The available amount of transaction currency during the completion of this transaction.
+     *
+     * @param \PayPal\Api\Amount $availableBalance
+     */
+    public function setAvailableBalance($availableBalance)
+    {
+        $this->availableBalance = $availableBalance;
+    }
+
+    /**
+     * The invoice ID that is sent by the merchant with the transaction.
+     *
+     * @return string
+     */
+    public function getInvoiceId()
+    {
+        return $this->invoiceId;
+    }
+
+    /**
+     * The invoice ID that is sent by the merchant with the transaction.
+     *
+     * @param mixed $invoiceId
+     */
+    public function setInvoiceId($invoiceId)
+    {
+        $this->invoiceId = $invoiceId;
+    }
+
+    /**
+     * Indicates whether the transaction is eligible for protection.
+     *
+     * @return mixed
+     */
+    public function getProtectionElegibility()
+    {
+        return $this->protectionElegibility;
+    }
+
+    /**
+     * Indicates whether the transaction is eligible for protection.
+     *
+     * @param mixed $protectionElegibility
+     */
+    public function setProtectionElegibility($protectionElegibility)
+    {
+        $this->protectionElegibility = $protectionElegibility;
+    }
+
+}

--- a/lib/PayPal/Api/ReportingTransactionInfo.php
+++ b/lib/PayPal/Api/ReportingTransactionInfo.php
@@ -251,21 +251,21 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * Indicates whether the transaction is eligible for protection.
      *
-     * @return mixed
+     * @return string
      */
-    public function getProtectionElegibility()
+    public function getProtectionEligibility()
     {
-        return $this->protectionElegibility;
+        return $this->protectionEligibility;
     }
 
     /**
      * Indicates whether the transaction is eligible for protection.
      *
-     * @param mixed $protectionElegibility
+     * @param string $protectionElegibility
      */
-    public function setProtectionElegibility($protectionElegibility)
+    public function setProtectionEligibility($protectionElegibility)
     {
-        $this->protectionElegibility = $protectionElegibility;
+        $this->protectionEligibility = $protectionElegibility;
     }
 
 }

--- a/lib/PayPal/Api/ReportingTransactionInfo.php
+++ b/lib/PayPal/Api/ReportingTransactionInfo.php
@@ -3,7 +3,6 @@
 
 namespace PayPal\Api;
 
-
 use PayPal\Common\PayPalModel;
 
 /**
@@ -267,5 +266,4 @@ class ReportingTransactionInfo extends PayPalModel
     {
         $this->protectionEligibility = $protectionElegibility;
     }
-
 }

--- a/lib/PayPal/Api/ReportingTransactionInfo.php
+++ b/lib/PayPal/Api/ReportingTransactionInfo.php
@@ -18,12 +18,12 @@ use PayPal\Common\PayPalModel;
  * @property string transaction_event_code
  * @property string transaction_initiation_date
  * @property string transaction_updated_date
- * @property \PayPal\Api\Amount transaction_amount
- * @property \PayPal\Api\Amount fee_amount
- * @property \PayPal\Api\Amount ending_balance
- * @property \PayPal\Api\Amount available_balance
- * @property \PayPal\Api\Amount invoice_id
- * @property \PayPal\Api\Amount protection_elegibility
+ * @property \PayPal\Api\ReportingTransactionAmount transaction_amount
+ * @property \PayPal\Api\ReportingTransactionAmount fee_amount
+ * @property \PayPal\Api\ReportingTransactionAmount ending_balance
+ * @property \PayPal\Api\ReportingTransactionAmount available_balance
+ * @property string invoice_id
+ * @property string protection_elegibility
  */
 class ReportingTransactionInfo extends PayPalModel
 {
@@ -131,7 +131,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The all-inclusive gross transaction amount that was transferred between the sender and receiver through PayPal.
      *
-     * @return \PayPal\Api\Amount
+     * @return \PayPal\Api\ReportingTransactionAmount
      */
     public function getTransactionAmount()
     {
@@ -141,7 +141,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The all-inclusive gross transaction amount that was transferred between the sender and receiver through PayPal.
      *
-     * @param \PayPal\Api\Amount $transactionAmount
+     * @param \PayPal\Api\ReportingTransactionAmount $transactionAmount
      */
     public function setTransactionAmount($transactionAmount)
     {
@@ -151,7 +151,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The PayPal fee amount. All transaction fees are included in this amount, which is the record of fee associated with the transaction.
      *
-     * @return \PayPal\Api\Amount
+     * @return \PayPal\Api\ReportingTransactionAmount
      */
     public function getFeeAmount()
     {
@@ -161,7 +161,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The PayPal fee amount. All transaction fees are included in this amount, which is the record of fee associated with the transaction.
      *
-     * @param \PayPal\Api\Amount $feeAmount
+     * @param \PayPal\Api\ReportingTransactionAmount $feeAmount
      */
     public function setFeeAmount($feeAmount)
     {
@@ -191,7 +191,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The ending balance.
      *
-     * @return \PayPal\Api\Amount
+     * @return \PayPal\Api\ReportingTransactionAmount
      */
     public function getEndingBalance()
     {
@@ -201,7 +201,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The ending balance.
      *
-     * @param \PayPal\Api\Amount $endingBalance
+     * @param \PayPal\Api\ReportingTransactionAmount $endingBalance
      */
     public function setEndingBalance($endingBalance)
     {
@@ -211,7 +211,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The available amount of transaction currency during the completion of this transaction.
      *
-     * @return \PayPal\Api\Amount
+     * @return \PayPal\Api\ReportingTransactionAmount
      */
     public function getAvailableBalance()
     {
@@ -221,7 +221,7 @@ class ReportingTransactionInfo extends PayPalModel
     /**
      * The available amount of transaction currency during the completion of this transaction.
      *
-     * @param \PayPal\Api\Amount $availableBalance
+     * @param \PayPal\Api\ReportingTransactionAmount $availableBalance
      */
     public function setAvailableBalance($availableBalance)
     {

--- a/lib/PayPal/Api/ReportingTransactions.php
+++ b/lib/PayPal/Api/ReportingTransactions.php
@@ -7,6 +7,7 @@ use PayPal\Core\PayPalConstants;
 use PayPal\Validation\ArgumentValidator;
 use PayPal\Rest\ApiContext;
 
+
 /**
  * Class ReportingTransactions
  *
@@ -17,8 +18,6 @@ use PayPal\Rest\ApiContext;
  */
 class ReportingTransactions extends PayPalResourceModel
 {
-    protected $startDate;
-    protected $endDate;
 
     protected $transactionDetails = array();
     protected $totalItems;
@@ -45,6 +44,7 @@ class ReportingTransactions extends PayPalResourceModel
      * @return \PayPal\Api\ReportingTransactionDetails[]
      */
     public function getTransactionDetails()
+    {
         return $this->transactionDetails;
     }
 
@@ -58,7 +58,21 @@ class ReportingTransactions extends PayPalResourceModel
         $this->transactionDetails = array_merge($this->transactionDetails, $transactionDetails);
     }
 
-    public static function get($params, $apiContext, $restCall = null) {
+    /**
+     * Lists transactions. Specify one or more query parameters to filter the transaction that appear in the response.
+     *
+     * @param array $params
+     *   Query parameters.
+     * @param \PayPal\Rest\ApiContext $apiContext
+     *   Api context.
+     * @param \PayPal\Transport\PayPalRestCall $restCall
+     *    Rest call.
+     *
+     * @return \PayPal\Api\ReportingTransactions
+     *   Reporting transactions response.
+     */
+    public static function get($params, $apiContext, $restCall = null)
+    {
         ArgumentValidator::validate($params, 'params');
         $payLoad = "";
         $allowedParams = array(
@@ -87,8 +101,8 @@ class ReportingTransactions extends PayPalResourceModel
         return $reporting_transactions;
     }
 
-    public static function all($params, $apiContext) {
-
+    public static function all($params, $apiContext)
+    {
     }
 
 }

--- a/lib/PayPal/Api/ReportingTransactions.php
+++ b/lib/PayPal/Api/ReportingTransactions.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace PayPal\Api;
+
+use PayPal\Common\PayPalResourceModel;
+use PayPal\Core\PayPalConstants;
+use PayPal\Validation\ArgumentValidator;
+use PayPal\Rest\ApiContext;
+
+/**
+ * Class ReportingTransactions
+ *
+ * Lets you get transactions using Paypal Sync api.
+ *
+ * @package PayPal\Api
+ *
+ */
+class ReportingTransactions extends PayPalResourceModel
+{
+    protected $startDate;
+    protected $endDate;
+    protected $transactionDetails = array();
+
+    /**
+     * @return \PayPal\Api\ReportingTransactionDetails[]
+     */
+    public function getTransactionDetails() {
+        return $this->transactionDetails;
+    }
+
+    public function setTransactionDetails($transactionDetails) {
+        $this->transactionDetails = $transactionDetails;
+    }
+
+    public static function get($params, $apiContext, $restCall = null) {
+        ArgumentValidator::validate($params, 'params');
+        $payLoad = "";
+        $allowedParams = array(
+            'transaction_amount' => 1,
+            'transaction_currency' => 1,
+            'start_date' => 1,
+            'end_date' => 1,
+            'payment_instrument_type' => 1,
+            'store_id' => 1,
+            'terminal_id' => 1,
+            'fields' => 1,
+            'balance_affecting_records_only' => 1,
+            'page_size' => 1,
+            'page' => 1,
+        );
+        $json = self::executeCall(
+            "/v1/reporting/transactions?" . http_build_query(array_intersect_key($params, $allowedParams)),
+            "GET",
+            $payLoad,
+            null,
+            $apiContext,
+            $restCall
+        );
+        $reporting_transactions = new ReportingTransactions();
+        $reporting_transactions->fromJson($json);
+        return $reporting_transactions;
+    }
+
+    public static function all($params, $apiContext) {
+
+    }
+
+}

--- a/lib/PayPal/Api/ReportingTransactions.php
+++ b/lib/PayPal/Api/ReportingTransactions.php
@@ -19,9 +19,26 @@ class ReportingTransactions extends PayPalResourceModel
 {
     protected $startDate;
     protected $endDate;
+
     protected $transactionDetails = array();
+    protected $totalItems;
 
     /**
+     * @return int
+     */
+    public function getTotalItems()
+    {
+        return $this->totalItems;
+    }
+
+    /**
+     * @param int $totalItems
+     */
+    public function setTotalItems($totalItems)
+    {
+        $this->totalItems = $totalItems;
+    }
+
      * @return \PayPal\Api\ReportingTransactionDetails[]
      */
     public function getTransactionDetails() {

--- a/lib/PayPal/Api/ReportingTransactions.php
+++ b/lib/PayPal/Api/ReportingTransactions.php
@@ -39,14 +39,23 @@ class ReportingTransactions extends PayPalResourceModel
         $this->totalItems = $totalItems;
     }
 
+    /**
+     * An array of transaction detail objects.
+     *
      * @return \PayPal\Api\ReportingTransactionDetails[]
      */
-    public function getTransactionDetails() {
+    public function getTransactionDetails()
         return $this->transactionDetails;
     }
 
-    public function setTransactionDetails($transactionDetails) {
-        $this->transactionDetails = $transactionDetails;
+    /**
+     * An array of transaction detail objects.
+     *
+     * @param \PayPal\Api\ReportingTransactionDetails[] $transactionDetails
+     */
+    public function setTransactionDetails($transactionDetails)
+    {
+        $this->transactionDetails = array_merge($this->transactionDetails, $transactionDetails);
     }
 
     public static function get($params, $apiContext, $restCall = null) {

--- a/sample/reporting-transactions/ListTransactions.php
+++ b/sample/reporting-transactions/ListTransactions.php
@@ -1,0 +1,24 @@
+<?php
+
+require __DIR__ . '/../bootstrap.php';
+use PayPal\Api\ReportingTransactions;
+
+// ### Retrieve payment
+// Retrieve the PaymentHistory object by calling the
+// static `get` method on the Payment class,
+// and pass a Map object that contains
+// query parameters for paginations and filtering.
+// Refer the method doc for valid values for keys
+// (See bootstrap.php for more on `ApiContext`)
+try {
+    $params = array('count' => 100, 'start_date' => '2019-03-20T00:00:00-0700', 'end_date' => '2019-04-10T23:59:59-0700', 'fields' => 'all', 'page' => 1);
+
+    $payments = ReportingTransactions::get($params, $apiContext);
+} catch (Exception $ex) {
+    // NOTE: PLEASE DO NOT USE RESULTPRINTER CLASS IN YOUR ORIGINAL CODE. FOR SAMPLE ONLY
+    ResultPrinter::printError("List Payments", "Payment", null, $params, $ex);
+    exit(1);
+}
+
+// NOTE: PLEASE DO NOT USE RESULTPRINTER CLASS IN YOUR ORIGINAL CODE. FOR SAMPLE ONLY
+ResultPrinter::printResult("List Payments", "Payment", null, $params, $payments);

--- a/sample/reporting-transactions/ListTransactions.php
+++ b/sample/reporting-transactions/ListTransactions.php
@@ -11,7 +11,7 @@ use PayPal\Api\ReportingTransactions;
 // Refer the method doc for valid values for keys
 // (See bootstrap.php for more on `ApiContext`)
 try {
-    $params = array('count' => 100, 'start_date' => '2019-03-20T00:00:00-0700', 'end_date' => '2019-04-10T23:59:59-0700', 'fields' => 'all', 'page' => 1);
+    $params = array('page_size' => 100, 'start_date' => '2019-03-20T00:00:00-0700', 'end_date' => '2019-04-10T23:59:59-0700', 'fields' => 'all', 'page' => 1);
 
     $response = ReportingTransactions::get($params, $apiContext);
 } catch (Exception $ex) {

--- a/sample/reporting-transactions/ListTransactions.php
+++ b/sample/reporting-transactions/ListTransactions.php
@@ -3,9 +3,9 @@
 require __DIR__ . '/../bootstrap.php';
 use PayPal\Api\ReportingTransactions;
 
-// ### Retrieve payment
-// Retrieve the PaymentHistory object by calling the
-// static `get` method on the Payment class,
+// ### List transactions.
+// Retrieve the reporting transaction list from object by calling the
+// static `get` method on the ReportingTransaction class,
 // and pass a Map object that contains
 // query parameters for paginations and filtering.
 // Refer the method doc for valid values for keys
@@ -13,7 +13,7 @@ use PayPal\Api\ReportingTransactions;
 try {
     $params = array('count' => 100, 'start_date' => '2019-03-20T00:00:00-0700', 'end_date' => '2019-04-10T23:59:59-0700', 'fields' => 'all', 'page' => 1);
 
-    $payments = ReportingTransactions::get($params, $apiContext);
+    $response = ReportingTransactions::get($params, $apiContext);
 } catch (Exception $ex) {
     // NOTE: PLEASE DO NOT USE RESULTPRINTER CLASS IN YOUR ORIGINAL CODE. FOR SAMPLE ONLY
     ResultPrinter::printError("List Payments", "Payment", null, $params, $ex);
@@ -21,4 +21,5 @@ try {
 }
 
 // NOTE: PLEASE DO NOT USE RESULTPRINTER CLASS IN YOUR ORIGINAL CODE. FOR SAMPLE ONLY
-ResultPrinter::printResult("List Payments", "Payment", null, $params, $payments);
+ResultPrinter::printResult("List transactions", "Payment", null, $params, $response);
+ResultPrinter::printResult("Transaction details", "Payment", null, $params, $response->getTransactionDetails());

--- a/sample/reporting-transactions/ListTransactionsAll.php
+++ b/sample/reporting-transactions/ListTransactionsAll.php
@@ -1,0 +1,23 @@
+<?php
+
+require __DIR__ . '/../bootstrap.php';
+use PayPal\Api\ReportingTransactions;
+
+// ### List all transactions.
+// Retrieve all the reporting transactions from object by calling the
+// static `all` method on the ReportingTransaction class,
+// Refer the method doc for valid values for keys
+// (See bootstrap.php for more on `ApiContext`)
+try {
+    $params = array('page_size' => 1, 'start_date' => '2019-03-20T00:00:00-0700', 'end_date' => '2019-04-10T23:59:59-0700', 'fields' => 'all');
+
+    $response = ReportingTransactions::all($params, $apiContext);
+} catch (Exception $ex) {
+    // NOTE: PLEASE DO NOT USE RESULTPRINTER CLASS IN YOUR ORIGINAL CODE. FOR SAMPLE ONLY
+    ResultPrinter::printError("List Payments", "Payment", null, $params, $ex);
+    exit(1);
+}
+
+// NOTE: PLEASE DO NOT USE RESULTPRINTER CLASS IN YOUR ORIGINAL CODE. FOR SAMPLE ONLY
+ResultPrinter::printResult("List transactions", "Payment", null, $params, $response);
+ResultPrinter::printResult("Transaction details", "Payment", null, $params, $response->getTransactionDetails());

--- a/tests/PayPal/Test/Api/ReportingTransactionsTest.php
+++ b/tests/PayPal/Test/Api/ReportingTransactionsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PayPal\Test\Api;
+
+use PayPal\Api\Payment;
+use PayPal\Api\ReportingTransactionInfo;
+use PHPUnit\Framework\TestCase;
+use PayPal\Api\ReportingTransactions;
+
+class ReportingTransactionsTest extends TestCase
+{
+    /**
+     * @dataProvider mockProvider
+     * @param Payment $obj
+     */
+    public function testGet($obj, $mockApiContext)
+    {
+        $mockPPRestCall = $this->getMockBuilder('\PayPal\Transport\PayPalRestCall')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockPPRestCall->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue(
+                ReportingTransactionsTest::getJson()
+            ));
+
+        $params = array('count' => 100, 'start_date' => '2019-03-20T00:00:00-0700', 'end_date' => '2019-04-10T23:59:59-0700', 'fields' => 'all', 'page' => 1);
+
+        /** @var \PayPal\Api\ReportingTransactions $transactions */
+        $transactions = $obj->get($params, $mockApiContext, $mockPPRestCall);
+        $this->assertInstanceOf('\PayPal\Api\ReportingTransactions', $transactions);
+        $transaction_details = $transactions->getTransactionDetails();
+        $this->assertTrue(is_array($transaction_details));
+        $this->assertInstanceOf('\PayPal\Api\ReportingTransactionDetails', reset($transaction_details));
+        /** @var ReportingTransactionInfo $transaction_info */
+        $transaction_info = $transaction_details[0]->getTransactionInfo();
+        $this->assertInstanceOf('\PayPal\Api\ReportingTransactionInfo', $transaction_info);
+        $this->assertEquals($transaction_info->getTransactionAmount()->getValue(), '50.00');
+        $this->assertEquals($transaction_info->getEndingBalance()->getValue(), '50.00');
+        $this->assertEquals($transaction_info->getInvoiceId(), '22892-1554291060');
+        $this->assertEquals($transaction_info->getTransactionId(), '61041S');
+        $this->assertEquals($transaction_info->getTransactionEventCode(), 'T0007');
+        // @TODO: finish transaction details assertions!
+    }
+
+    public static function getJson()
+    {
+        return '{"transaction_details":[{"transaction_info":{"paypal_account_id":"1234","transaction_id":"61041S","transaction_event_code":"T0007","transaction_initiation_date":"2019-04-03T11:33:04+0000","transaction_updated_date":"2019-04-03T11:33:04+0000","transaction_amount":{"currency_code":"EUR","value":"50.00"},"fee_amount":{"currency_code":"EUR","value":"-42.31"},"transaction_status":"S","ending_balance":{"currency_code":"EUR","value":"50.00"},"available_balance":{"currency_code":"EUR","value":"50.00"},"invoice_id":"22892-1554291060","protection_eligibility":"01"},"payer_info":{"account_id":"1234","email_address":"debug@example.com","address_status":"N","payer_status":"Y","payer_name":{"given_name":"test","surname":"buyer","alternate_full_name":"test buyer"},"country_code":"ES"},"shipping_info":{"name":"test, buyer"},"cart_info":{"item_details":[{"item_name":"Example","item_quantity":"1","item_unit_price":{"currency_code":"EUR","value":"50.00"},"item_amount":{"currency_code":"EUR","value":"50.00"},"total_item_amount":{"currency_code":"EUR","value":"50.00"},"invoice_number":"22892-1554291060","checkout_options":[{"checkout_option_name":"Product quantity","checkout_option_value":"1"}]}]},"store_info":{},"auction_info":{},"incentive_info":{}}],"account_number":"12345Y","start_date":"2019-03-20T07:00:00+0000","end_date":"2019-04-04T08:59:59+0000","last_refreshed_datetime":"2019-04-04T08:59:59+0000","page":1,"total_items":2,"total_pages":1,"links":[{"href":"https://api.sandbox.paypal.com/v1/reporting/transactions?start_date=2019-03-20T00%3A00%3A00-0700&end_date=2019-04-10T23%3A59%3A59-0700&fields=all&page_size=100&page=1","rel":"self","method":"GET"}]}';
+    }
+
+    /**
+     * Gets Object Instance with Json data filled in
+     * @return Payment
+     */
+    public static function getObject()
+    {
+        return new ReportingTransactions(self::getJson());
+    }
+
+    public function mockProvider()
+    {
+        $obj = self::getObject();
+        $mockApiContext = $this->getMockBuilder('ApiContext')
+            ->disableOriginalConstructor()
+            ->getMock();
+        return array(
+            array($obj, $mockApiContext),
+            array($obj, null)
+        );
+    }
+
+}

--- a/tests/PayPal/Test/Api/ReportingTransactionsTest.php
+++ b/tests/PayPal/Test/Api/ReportingTransactionsTest.php
@@ -30,6 +30,7 @@ class ReportingTransactionsTest extends TestCase
         /** @var \PayPal\Api\ReportingTransactions $transactions */
         $transactions = $obj->get($params, $mockApiContext, $mockPPRestCall);
         $this->assertInstanceOf('\PayPal\Api\ReportingTransactions', $transactions);
+        $this->assertEquals(2, $transactions->getTotalItems());
         $transaction_details = $transactions->getTransactionDetails();
         $this->assertTrue(is_array($transaction_details));
         $this->assertInstanceOf('\PayPal\Api\ReportingTransactionDetails', reset($transaction_details));
@@ -78,5 +79,4 @@ class ReportingTransactionsTest extends TestCase
             array($obj, null)
         );
     }
-
 }

--- a/tests/PayPal/Test/Api/ReportingTransactionsTest.php
+++ b/tests/PayPal/Test/Api/ReportingTransactionsTest.php
@@ -9,6 +9,7 @@ use PayPal\Api\ReportingTransactions;
 
 class ReportingTransactionsTest extends TestCase
 {
+
     /**
      * @dataProvider mockProvider
      * @param Payment $obj
@@ -29,6 +30,42 @@ class ReportingTransactionsTest extends TestCase
 
         /** @var \PayPal\Api\ReportingTransactions $transactions */
         $transactions = $obj->get($params, $mockApiContext, $mockPPRestCall);
+        $this->assertTransactionValuesAreCorrect($transactions);
+    }
+
+    /**
+     * @dataProvider mockProvider
+     * @param Payment $obj
+     */
+    public function testAll($obj, $mockApiContext)
+    {
+        $mockPPRestCall = $this->getMockBuilder('\PayPal\Transport\PayPalRestCall')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockPPRestCall->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue(
+                ReportingTransactionsTest::getJson()
+            ));
+
+        $params = array('count' => 100, 'start_date' => '2019-03-20T00:00:00-0700', 'end_date' => '2019-04-10T23:59:59-0700', 'fields' => 'all', 'page' => 1);
+
+        /** @var \PayPal\Api\ReportingTransactions $transactions */
+        $transactions = $obj->get($params, $mockApiContext, $mockPPRestCall);
+        $this->assertTransactionValuesAreCorrect($transactions);
+    }
+
+    /**
+     * Make all assertions for the reporting transactions response.
+     *
+     * Used for ::get and ::all.
+     *
+     * @param \PayPal\Api\ReportingTransactions $transactions
+     *   Transactions.
+     */
+    public function assertTransactionValuesAreCorrect($transactions)
+    {
         $this->assertInstanceOf('\PayPal\Api\ReportingTransactions', $transactions);
         $this->assertEquals(2, $transactions->getTotalItems());
         $transaction_details = $transactions->getTransactionDetails();

--- a/tests/PayPal/Test/Api/ReportingTransactionsTest.php
+++ b/tests/PayPal/Test/Api/ReportingTransactionsTest.php
@@ -37,11 +37,20 @@ class ReportingTransactionsTest extends TestCase
         $transaction_info = $transaction_details[0]->getTransactionInfo();
         $this->assertInstanceOf('\PayPal\Api\ReportingTransactionInfo', $transaction_info);
         $this->assertEquals($transaction_info->getTransactionAmount()->getValue(), '50.00');
+        $this->assertEquals($transaction_info->getTransactionAmount()->getCurrencyCode(), 'EUR');
         $this->assertEquals($transaction_info->getEndingBalance()->getValue(), '50.00');
+        $this->assertEquals($transaction_info->getEndingBalance()->getCurrencyCode(), 'EUR');
+        $this->assertEquals($transaction_info->getAvailableBalance()->getValue(), '50.00');
+        $this->assertEquals($transaction_info->getAvailableBalance()->getCurrencyCode(), 'EUR');
+        $this->assertEquals($transaction_info->getFeeAmount()->getValue(), '-42.31');
+        $this->assertEquals($transaction_info->getFeeAmount()->getCurrencyCode(), 'EUR');
         $this->assertEquals($transaction_info->getInvoiceId(), '22892-1554291060');
         $this->assertEquals($transaction_info->getTransactionId(), '61041S');
         $this->assertEquals($transaction_info->getTransactionEventCode(), 'T0007');
-        // @TODO: finish transaction details assertions!
+        $this->assertEquals($transaction_info->getTransactionInitiationDate(), '2019-04-03T11:33:04+0000');
+        $this->assertEquals($transaction_info->getTransactionUpdatedDate(), '2019-04-03T11:33:04+0000');
+        $this->assertEquals($transaction_info->getProtectionEligibility(), '01');
+        $this->assertEquals($transaction_info->getPaypalAccountId(), '1234');
     }
 
     public static function getJson()

--- a/tests/PayPal/Test/Api/ReportingTransactionsTest.php
+++ b/tests/PayPal/Test/Api/ReportingTransactionsTest.php
@@ -54,6 +54,12 @@ class ReportingTransactionsTest extends TestCase
         $this->assertEquals($transaction_info->getPaypalAccountId(), '1234');
     }
 
+    /**
+     * Get the mock json for paypal sync api response.
+     *
+     * @return string
+     *   Json encoded.
+     */
     public static function getJson()
     {
         return '{"transaction_details":[{"transaction_info":{"paypal_account_id":"1234","transaction_id":"61041S","transaction_event_code":"T0007","transaction_initiation_date":"2019-04-03T11:33:04+0000","transaction_updated_date":"2019-04-03T11:33:04+0000","transaction_amount":{"currency_code":"EUR","value":"50.00"},"fee_amount":{"currency_code":"EUR","value":"-42.31"},"transaction_status":"S","ending_balance":{"currency_code":"EUR","value":"50.00"},"available_balance":{"currency_code":"EUR","value":"50.00"},"invoice_id":"22892-1554291060","protection_eligibility":"01"},"payer_info":{"account_id":"1234","email_address":"debug@example.com","address_status":"N","payer_status":"Y","payer_name":{"given_name":"test","surname":"buyer","alternate_full_name":"test buyer"},"country_code":"ES"},"shipping_info":{"name":"test, buyer"},"cart_info":{"item_details":[{"item_name":"Example","item_quantity":"1","item_unit_price":{"currency_code":"EUR","value":"50.00"},"item_amount":{"currency_code":"EUR","value":"50.00"},"total_item_amount":{"currency_code":"EUR","value":"50.00"},"invoice_number":"22892-1554291060","checkout_options":[{"checkout_option_name":"Product quantity","checkout_option_value":"1"}]}]},"store_info":{},"auction_info":{},"incentive_info":{}}],"account_number":"12345Y","start_date":"2019-03-20T07:00:00+0000","end_date":"2019-04-04T08:59:59+0000","last_refreshed_datetime":"2019-04-04T08:59:59+0000","page":1,"total_items":2,"total_pages":1,"links":[{"href":"https://api.sandbox.paypal.com/v1/reporting/transactions?start_date=2019-03-20T00%3A00%3A00-0700&end_date=2019-04-10T23%3A59%3A59-0700&fields=all&page_size=100&page=1","rel":"self","method":"GET"}]}';
@@ -68,6 +74,12 @@ class ReportingTransactionsTest extends TestCase
         return new ReportingTransactions(self::getJson());
     }
 
+    /**
+     * Data provider to get the mocked http client.
+     *
+     * @return array
+     *   Data provider parameters.
+     */
     public function mockProvider()
     {
         $obj = self::getObject();


### PR DESCRIPTION
This pull request brings an initial integration with [paypal sync api](https://developer.paypal.com/docs/api/sync/v1/). I need this for a project.

It only process fields from transaction_info, other fields are not processed.

Please review, suggest anything to improve this.