### PR TITLE
Note to payer property

### DIFF
--- a/lib/PayPal/Api/Capture.php
+++ b/lib/PayPal/Api/Capture.php
@@ -22,6 +22,7 @@ use PayPal\Rest\ApiContext;
  * @property string parent_payment
  * @property string invoice_number
  * @property \PayPal\Api\Currency transaction_fee
+ * @property string note_to_payer
  * @property string create_time
  * @property string update_time
  * @property \PayPal\Api\Links[] links

--- a/sample/payments/AuthorizationCapture.php
+++ b/sample/payments/AuthorizationCapture.php
@@ -5,6 +5,7 @@
 // API used: /v1/payments/payment
 // https://developer.paypal.com/docs/api/#capture-an-authorization
 
+require __DIR__ . '/../bootstrap.php';
 use PayPal\Api\Amount;
 use PayPal\Api\Authorization;
 use PayPal\Api\Capture;
@@ -29,6 +30,7 @@ try {
     ### Capture
     $capture = new Capture();
     $capture->setAmount($amt);
+    $capture->setNoteToPayer("Contact us for any questions on your order.");
 
     // Perform a capture
     $getCapture = $authorization->capture($capture, $apiContext);

--- a/tests/PayPal/Test/Api/CaptureTest.php
+++ b/tests/PayPal/Test/Api/CaptureTest.php
@@ -19,7 +19,7 @@ class CaptureTest extends TestCase
      */
     public static function getJson()
     {
-        return '{"id":"TestSample","amount":' .AmountTest::getJson() . ',"is_final_capture":true,"state":"TestSample","reason_code":"TestSample","parent_payment":"TestSample","invoice_number":"TestSample","transaction_fee":' .CurrencyTest::getJson() . ',"note_to_payer":"TestSample","create_time":"TestSample","update_time":"TestSample","links":' .LinksTest::getJson() . '}';
+        return '{"id":"TestSample","amount":' .AmountTest::getJson() . ',"is_final_capture":true,"state":"TestSample","reason_code":"TestSample","parent_payment":"TestSample","invoice_number":"TestSample","transaction_fee":' .CurrencyTest::getJson() . ',"note_to_payer":"Contact us for any questions on your order.","create_time":"TestSample","update_time":"TestSample","links":' .LinksTest::getJson() . '}';
     }
 
     /**
@@ -70,7 +70,7 @@ class CaptureTest extends TestCase
         $this->assertEquals($obj->getParentPayment(), "TestSample");
         $this->assertEquals($obj->getInvoiceNumber(), "TestSample");
         $this->assertEquals($obj->getTransactionFee(), CurrencyTest::getObject());
-        $this->assertEquals($obj->getNoteToPayer(), "TestSample");
+        $this->assertEquals($obj->getNoteToPayer(), "Contact us for any questions on your order.");
         $this->assertEquals($obj->getCreateTime(), "TestSample");
         $this->assertEquals($obj->getUpdateTime(), "TestSample");
         $this->assertEquals($obj->getLinks(), LinksTest::getObject());


### PR DESCRIPTION
Adding note_to_payer property to Capture class 
Doc link : https://developer.paypal.com/docs/api/payments/v1/#capture accepts a free-form-field called note_to_payer to send a note to the payer.
**Sample request and response**:
![image](https://user-images.githubusercontent.com/13796434/66113810-26a60300-e5eb-11e9-8a89-442ddf2f824d.png)
