### PR TITLE
Removes weak comparison from NumericValidator

### DIFF
--- a/lib/PayPal/Validation/NumericValidator.php
+++ b/lib/PayPal/Validation/NumericValidator.php
@@ -19,7 +19,7 @@ class NumericValidator
      */
     public static function validate($argument, $argumentName = null)
     {
-        if (trim($argument) != null && !is_numeric($argument)) {
+        if (trim($argument) !== '' && !is_numeric($argument)) {
             throw new \InvalidArgumentException("$argumentName is not a valid numeric value");
         }
         return true;


### PR DESCRIPTION
`trim(null)` returns `string(0) ""`, so relying on a weak comparsion can be confusing to read and possibly unreliable in the future.